### PR TITLE
Fix movement up tower

### DIFF
--- a/Assets/Prefabs/FloorSpawn.prefab
+++ b/Assets/Prefabs/FloorSpawn.prefab
@@ -33,7 +33,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1043897412465426}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -16, y: 21.65, z: -44.89}
+  m_LocalPosition: {x: -34.94, y: 21.65, z: -44.89}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/Prefabs/Players and Cameras/Player 1 Camera.prefab
+++ b/Assets/Prefabs/Players and Cameras/Player 1 Camera.prefab
@@ -9,18 +9,18 @@ Prefab:
     m_Modifications: []
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1471729872254108}
+  m_RootGameObject: {fileID: 1183158076117892}
   m_IsPrefabAsset: 1
---- !u!1 &1471729872254108
+--- !u!1 &1183158076117892
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4124782476045882}
-  - component: {fileID: 20029879623837878}
-  - component: {fileID: 81888765460848792}
+  - component: {fileID: 4097841291162254}
+  - component: {fileID: 20127244597484544}
+  - component: {fileID: 81786580490577294}
   m_Layer: 0
   m_Name: Player 1 Camera
   m_TagString: Untagged
@@ -28,25 +28,25 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4124782476045882
+--- !u!4 &4097841291162254
 Transform:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1471729872254108}
-  m_LocalRotation: {x: 0.08715578, y: 0, z: 0, w: 0.9961947}
-  m_LocalPosition: {x: 0, y: 5, z: -45}
+  m_GameObject: {fileID: 1183158076117892}
+  m_LocalRotation: {x: 0.043619405, y: -0, z: -0, w: 0.9990483}
+  m_LocalPosition: {x: -36.4, y: 12, z: -70.89}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 10, y: 0, z: 0}
---- !u!20 &20029879623837878
+  m_LocalEulerAnglesHint: {x: 5, y: 0, z: 0}
+--- !u!20 &20127244597484544
 Camera:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1471729872254108}
+  m_GameObject: {fileID: 1183158076117892}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
@@ -81,10 +81,10 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
---- !u!81 &81888765460848792
+--- !u!81 &81786580490577294
 AudioListener:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1471729872254108}
+  m_GameObject: {fileID: 1183158076117892}
   m_Enabled: 1

--- a/Assets/Prefabs/Players and Cameras/Player 1.prefab
+++ b/Assets/Prefabs/Players and Cameras/Player 1.prefab
@@ -81,23 +81,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1505816472272982
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4228067770503704}
-  - component: {fileID: 20629428929373556}
-  - component: {fileID: 81698374894019034}
-  m_Layer: 0
-  m_Name: Player 1 Camera
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &1640768522245996
 GameObject:
   m_ObjectHideFlags: 1
@@ -115,19 +98,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4228067770503704
-Transform:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1505816472272982}
-  m_LocalRotation: {x: 0.043619405, y: 0, z: 0, w: 0.9990483}
-  m_LocalPosition: {x: 0, y: 20, z: -45}
-  m_LocalScale: {x: 2, y: 2, z: 2}
-  m_Children: []
-  m_Father: {fileID: 4887500721987680}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 5, y: 0, z: 0}
 --- !u!4 &4470643898870020
 Transform:
   m_ObjectHideFlags: 1
@@ -181,7 +151,6 @@ Transform:
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_Children:
   - {fileID: 4512526300849048}
-  - {fileID: 4228067770503704}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -198,46 +167,6 @@ Transform:
   m_Father: {fileID: 4512526300849048}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!20 &20629428929373556
-Camera:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1505816472272982}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 2
-  m_BackGroundColor: {r: 0.3820755, g: 0.6223794, b: 1, a: 0}
-  m_projectionMatrixMode: 1
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 0.5
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 0
-  orthographic size: 5
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
 --- !u!23 &23087665736016806
 MeshRenderer:
   m_ObjectHideFlags: 1
@@ -433,13 +362,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 3.6977558, z: 1}
   m_Center: {x: 0, y: 0.755188, z: 0}
---- !u!81 &81698374894019034
-AudioListener:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1505816472272982}
-  m_Enabled: 1
 --- !u!114 &114614076012222384
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -451,7 +373,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8a99e4dd110c91541b836d45d1d5ecd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerOneCam: {fileID: 20629428929373556}
+  playerOneCam: {fileID: 0}
   moveSpeed: 0.5
   playerModel: {fileID: 1101359674135618}
   wall: {fileID: 1074624622806958, guid: db135b0f7b963ae48b5599f5a08f5d03, type: 2}

--- a/Assets/Prefabs/Players and Cameras/Player 1.prefab
+++ b/Assets/Prefabs/Players and Cameras/Player 1.prefab
@@ -121,13 +121,13 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1505816472272982}
-  m_LocalRotation: {x: 0.08715578, y: 0, z: 0, w: 0.9961947}
-  m_LocalPosition: {x: 0, y: 10, z: -45}
+  m_LocalRotation: {x: 0.043619405, y: 0, z: 0, w: 0.9990483}
+  m_LocalPosition: {x: 0, y: 20, z: -45}
   m_LocalScale: {x: 2, y: 2, z: 2}
   m_Children: []
   m_Father: {fileID: 4887500721987680}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 10, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 5, y: 0, z: 0}
 --- !u!4 &4470643898870020
 Transform:
   m_ObjectHideFlags: 1
@@ -454,9 +454,13 @@ MonoBehaviour:
   playerOneCam: {fileID: 20629428929373556}
   moveSpeed: 0.5
   playerModel: {fileID: 1101359674135618}
-  wall: {fileID: 1304183516199084, guid: db135b0f7b963ae48b5599f5a08f5d03, type: 2}
+  wall: {fileID: 1074624622806958, guid: db135b0f7b963ae48b5599f5a08f5d03, type: 2}
   rotateTriggers:
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  wallTriggers:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}

--- a/Assets/Prefabs/Wall.prefab
+++ b/Assets/Prefabs/Wall.prefab
@@ -9,20 +9,19 @@ Prefab:
     m_Modifications: []
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1304183516199084}
+  m_RootGameObject: {fileID: 1074624622806958}
   m_IsPrefabAsset: 1
---- !u!1 &1304183516199084
+--- !u!1 &1074624622806958
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4586462100639018}
-  - component: {fileID: 33136736325497376}
-  - component: {fileID: 23136382930086786}
-  - component: {fileID: 65154423136798334}
-  - component: {fileID: 54876695158984886}
+  - component: {fileID: 4946581238130944}
+  - component: {fileID: 33630043031672614}
+  - component: {fileID: 23233914847166442}
+  - component: {fileID: 65571364396891378}
   m_Layer: 0
   m_Name: Wall
   m_TagString: Untagged
@@ -30,26 +29,26 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4586462100639018
+--- !u!4 &4946581238130944
 Transform:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1304183516199084}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -19.5, y: 5, z: -25}
-  m_LocalScale: {x: 0.5, y: 9, z: 10}
+  m_GameObject: {fileID: 1074624622806958}
+  m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 50, y: 10, z: -40.25}
+  m_LocalScale: {x: 20, y: 19, z: 0.5}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &23136382930086786
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
+--- !u!23 &23233914847166442
 MeshRenderer:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1304183516199084}
-  m_Enabled: 0
+  m_GameObject: {fileID: 1074624622806958}
+  m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -58,7 +57,7 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
   m_Materials:
-  - {fileID: 2100000, guid: a6159130d2ec1d24485033186ab84fbe, type: 2}
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -78,34 +77,19 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!33 &33136736325497376
+--- !u!33 &33630043031672614
 MeshFilter:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1304183516199084}
+  m_GameObject: {fileID: 1074624622806958}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!54 &54876695158984886
-Rigidbody:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1304183516199084}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 1
-  m_Interpolate: 0
-  m_Constraints: 126
-  m_CollisionDetection: 0
---- !u!65 &65154423136798334
+--- !u!65 &65571364396891378
 BoxCollider:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1304183516199084}
+  m_GameObject: {fileID: 1074624622806958}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1

--- a/Assets/Scenes/Tower1.unity
+++ b/Assets/Scenes/Tower1.unity
@@ -301,6 +301,48 @@ Prefab:
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c17f18a57460024ba6258242e429410, type: 2}
   m_IsPrefabAsset: 0
+--- !u!1001 &230568126
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4097841291162254, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: -36.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4097841291162254, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 4097841291162254, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -70.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 4097841291162254, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0.043619405
+      objectReference: {fileID: 0}
+    - target: {fileID: 4097841291162254, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4097841291162254, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4097841291162254, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 0.9990483
+      objectReference: {fileID: 0}
+    - target: {fileID: 4097841291162254, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!114 &401793270 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114325303488596344, guid: c130ae0761b27334089036b39347c937,
@@ -371,116 +413,6 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 1081506436}
   m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
---- !u!1001 &876396338
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
-        type: 2}
-      propertyPath: wallTriggers.Array.size
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -36.4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -48.39
-      objectReference: {fileID: 0}
-    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
-        type: 2}
-      propertyPath: rotateTriggers.Array.data[0]
-      value: 
-      objectReference: {fileID: 1074817019}
-    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
-        type: 2}
-      propertyPath: rotateTriggers.Array.data[1]
-      value: 
-      objectReference: {fileID: 972572236}
-    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
-        type: 2}
-      propertyPath: rotateTriggers.Array.data[2]
-      value: 
-      objectReference: {fileID: 497557894}
-    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
-        type: 2}
-      propertyPath: rotateTriggers.Array.data[3]
-      value: 
-      objectReference: {fileID: 1629728421}
-    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
-        type: 2}
-      propertyPath: floorSpawn
-      value: 
-      objectReference: {fileID: 1578063161}
-    - target: {fileID: 114940724036334842, guid: 9af0d0883e6a51441b06cd7d26274b01,
-        type: 2}
-      propertyPath: gameManager
-      value: 
-      objectReference: {fileID: 1016487807}
-    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
-        type: 2}
-      propertyPath: wallTriggers.Array.data[0]
-      value: 
-      objectReference: {fileID: 55092593}
-    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
-        type: 2}
-      propertyPath: wallTriggers.Array.data[1]
-      value: 
-      objectReference: {fileID: 153644551}
-    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
-        type: 2}
-      propertyPath: wallTriggers.Array.data[2]
-      value: 
-      objectReference: {fileID: 2109003900}
-    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
-        type: 2}
-      propertyPath: wall
-      value: 
-      objectReference: {fileID: 1074624622806958, guid: db135b0f7b963ae48b5599f5a08f5d03,
-        type: 2}
-    - target: {fileID: 4228067770503704, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0.043619405
-      objectReference: {fileID: 0}
-    - target: {fileID: 4228067770503704, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 0.9990483
-      objectReference: {fileID: 0}
-    - target: {fileID: 4228067770503704, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 5
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
-  m_IsPrefabAsset: 0
 --- !u!114 &960280925 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114684309664505246, guid: 7c17f18a57460024ba6258242e429410,
@@ -532,6 +464,11 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &1022843377 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 20127244597484544, guid: 415a8da459df20b4ba20fdbb2acbdc98,
+    type: 2}
+  m_PrefabInternal: {fileID: 230568126}
 --- !u!1 &1074817019 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1695926494504056, guid: ff9fcda491d07404283d525387473970,
@@ -827,6 +764,98 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1171149859
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: -36.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -48.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 114940724036334842, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: gameManager
+      value: 
+      objectReference: {fileID: 1016487807}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: playerOneCam
+      value: 
+      objectReference: {fileID: 1022843377}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: rotateTriggers.Array.data[0]
+      value: 
+      objectReference: {fileID: 1074817019}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: rotateTriggers.Array.data[1]
+      value: 
+      objectReference: {fileID: 972572236}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: rotateTriggers.Array.data[2]
+      value: 
+      objectReference: {fileID: 497557894}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: rotateTriggers.Array.data[3]
+      value: 
+      objectReference: {fileID: 1629728421}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: wallTriggers.Array.data[0]
+      value: 
+      objectReference: {fileID: 55092593}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: wallTriggers.Array.data[1]
+      value: 
+      objectReference: {fileID: 153644551}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: wallTriggers.Array.data[2]
+      value: 
+      objectReference: {fileID: 2109003900}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: floorSpawn
+      value: 
+      objectReference: {fileID: 1578063161}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!4 &1578063161 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d,

--- a/Assets/Scenes/Tower1.unity
+++ b/Assets/Scenes/Tower1.unity
@@ -113,6 +113,16 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &55092593 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1674693470272370, guid: ff9fcda491d07404283d525387473970,
+    type: 2}
+  m_PrefabInternal: {fileID: 1140044042}
+--- !u!1 &153644551 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1510441196117610, guid: ff9fcda491d07404283d525387473970,
+    type: 2}
+  m_PrefabInternal: {fileID: 1140044042}
 --- !u!1 &170076733
 GameObject:
   m_ObjectHideFlags: 0
@@ -291,11 +301,6 @@ Prefab:
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c17f18a57460024ba6258242e429410, type: 2}
   m_IsPrefabAsset: 0
---- !u!4 &352250307 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d,
-    type: 2}
-  m_PrefabInternal: {fileID: 1500884541}
 --- !u!114 &401793270 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114325303488596344, guid: c130ae0761b27334089036b39347c937,
@@ -312,6 +317,48 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1665096163155028, guid: ff9fcda491d07404283d525387473970,
     type: 2}
   m_PrefabInternal: {fileID: 1140044042}
+--- !u!1001 &673069878
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: -34.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 21.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -44.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!114 &695091538 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114319099969557882, guid: c130ae0761b27334089036b39347c937,
@@ -331,6 +378,11 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: wallTriggers.Array.size
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 4887500721987680, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
       propertyPath: m_LocalPosition.x
       value: -36.4
@@ -387,12 +439,45 @@ Prefab:
         type: 2}
       propertyPath: floorSpawn
       value: 
-      objectReference: {fileID: 352250307}
+      objectReference: {fileID: 1578063161}
     - target: {fileID: 114940724036334842, guid: 9af0d0883e6a51441b06cd7d26274b01,
         type: 2}
       propertyPath: gameManager
       value: 
       objectReference: {fileID: 1016487807}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: wallTriggers.Array.data[0]
+      value: 
+      objectReference: {fileID: 55092593}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: wallTriggers.Array.data[1]
+      value: 
+      objectReference: {fileID: 153644551}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: wallTriggers.Array.data[2]
+      value: 
+      objectReference: {fileID: 2109003900}
+    - target: {fileID: 114614076012222384, guid: 9af0d0883e6a51441b06cd7d26274b01,
+        type: 2}
+      propertyPath: wall
+      value: 
+      objectReference: {fileID: 1074624622806958, guid: db135b0f7b963ae48b5599f5a08f5d03,
+        type: 2}
+    - target: {fileID: 4228067770503704, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0.043619405
+      objectReference: {fileID: 0}
+    - target: {fileID: 4228067770503704, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 0.9990483
+      objectReference: {fileID: 0}
+    - target: {fileID: 4228067770503704, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 5
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9af0d0883e6a51441b06cd7d26274b01, type: 2}
   m_IsPrefabAsset: 0
@@ -445,7 +530,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1074817019 stripped
 GameObject:
@@ -497,7 +582,7 @@ Prefab:
     - target: {fileID: 224102324204962692, guid: c130ae0761b27334089036b39347c937,
         type: 2}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 224102324204962692, guid: c130ae0761b27334089036b39347c937,
         type: 2}
@@ -740,50 +825,13 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1500884541
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -16
-      objectReference: {fileID: 0}
-    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 21.65
-      objectReference: {fileID: 0}
-    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -44.89
-      objectReference: {fileID: 0}
-    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 26dfc7ca8379bc24185ef28fb6acd97d, type: 2}
-  m_IsPrefabAsset: 0
+--- !u!4 &1578063161 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4285895652612146, guid: 26dfc7ca8379bc24185ef28fb6acd97d,
+    type: 2}
+  m_PrefabInternal: {fileID: 673069878}
 --- !u!1 &1629728421 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1917442397181180, guid: ff9fcda491d07404283d525387473970,
@@ -885,3 +933,8 @@ Prefab:
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 295df6c694235764eac79c393ed826dc, type: 2}
   m_IsPrefabAsset: 0
+--- !u!1 &2109003900 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1491876165270482, guid: ff9fcda491d07404283d525387473970,
+    type: 2}
+  m_PrefabInternal: {fileID: 1140044042}

--- a/Assets/Scripts/Cameras/CameraOneRotator.cs
+++ b/Assets/Scripts/Cameras/CameraOneRotator.cs
@@ -15,8 +15,8 @@ public class CameraOneRotator : MonoBehaviour {
     [SerializeField] private Transform floorSpawn;
 
     //Change these if the tower is scaled
-    private static int camPosHorizontal = 45;
-    private static int camPosVertical   = 20;
+    private static int camPosHorizontal = 25;
+    private static int camPosVertical   = 13;
     private static int camRotationX     = 5;
     private static int camRotationY     = 0;
     private static int numFloors = 10;
@@ -44,6 +44,26 @@ public class CameraOneRotator : MonoBehaviour {
         rb = GetComponent<Rigidbody>();
     }
 
+    private void Update()
+    {
+        switch(cameraState)
+        {
+            case 1:
+                playerOneCam.transform.position = new Vector3(playerModel.transform.position.x, playerOneCam.transform.position.y, playerModel.transform.position.z - camPosHorizontal);
+                break;
+            case 2:
+                playerOneCam.transform.position = new Vector3(playerModel.transform.position.x + camPosHorizontal, playerOneCam.transform.position.y, playerModel.transform.position.z);
+                break;
+            case 3:
+                playerOneCam.transform.position = new Vector3(playerModel.transform.position.x, playerOneCam.transform.position.y, playerModel.transform.position.z + camPosHorizontal);
+                break;
+            case 4:
+                playerOneCam.transform.position = new Vector3(playerModel.transform.position.x - camPosHorizontal, playerOneCam.transform.position.y, playerModel.transform.position.z);
+                break;
+
+        }
+    }
+
     //4 triggers for rotating camera, 3 for putting up walls behind the player
     private void OnTriggerEnter(Collider other)
     {
@@ -54,13 +74,13 @@ public class CameraOneRotator : MonoBehaviour {
         switch (other.tag)
         {
             case "Trigger1":
-                StartMove(basePositions[1], rotations[1], 2);
+                StartMove(new Vector3(playerModel.transform.position.x + camPosHorizontal, playerOneCam.transform.position.y, playerModel.transform.position.z + 5), rotations[1], 2);
                 break;
             case "Trigger2":
-                StartMove(basePositions[2], rotations[2], 3);
+                StartMove(new Vector3(playerModel.transform.position.x - 5, playerOneCam.transform.position.y, playerModel.transform.position.z + camPosHorizontal), rotations[2], 3);
                 break;
             case "Trigger3":
-                StartMove(basePositions[3], rotations[3], 4);
+                StartMove(new Vector3(playerModel.transform.position.x - camPosHorizontal, playerOneCam.transform.position.y, playerModel.transform.position.z), rotations[3], 4);
                 break;
             case "Trigger4":
                 Debug.Log("Move up");
@@ -68,12 +88,12 @@ public class CameraOneRotator : MonoBehaviour {
                 {
                     floor++;
                     MovePlayerUp();
-                    StartMove(basePositions[0], rotations[0], 1);
+                    StartMove(new Vector3(playerModel.transform.position.x, playerOneCam.transform.position.y + 20, playerModel.transform.position.z - camPosHorizontal), rotations[0], 1);
                     break;
                 }
                 else
                 {
-                    StartMove(basePositions[0], rotations[0], 1);
+                    StartMove(new Vector3(playerModel.transform.position.x, playerOneCam.transform.position.y + 20, playerModel.transform.position.z - camPosHorizontal), rotations[0], 1);
                     break;
                 }
             case "Wall1":
@@ -116,12 +136,12 @@ public class CameraOneRotator : MonoBehaviour {
 
         for (float t = 0; t < time; t += Time.deltaTime)
         {
-            playerOneCam.transform.localPosition = Vector3.Lerp(currentPos, targetPos, t/time);
+            playerOneCam.transform.position = Vector3.Lerp(currentPos, targetPos, t/time);
             playerOneCam.transform.rotation = Quaternion.Slerp(currentRot, targetRot, t/time);
             yield return null;
         }
 
-        playerOneCam.transform.localPosition = targetPos;
+        //playerOneCam.transform.po
         playerOneCam.transform.rotation = targetRot;
         camTween = null;
     }
@@ -130,6 +150,7 @@ public class CameraOneRotator : MonoBehaviour {
     private void MovePlayerUp()
     {
         this.transform.position = floorSpawn.position + Vector3.up * 20 * (floor - 2);
+        //playerOneCam.transform.position = new Vector3(playerModel.transform.position.x, playerOneCam.transform.position.y+20, playerModel.transform.position.z - camPosHorizontal);
     }
 
     //Rotate the player model when you move around the tower

--- a/Assets/Scripts/Cameras/CameraOneRotator.cs
+++ b/Assets/Scripts/Cameras/CameraOneRotator.cs
@@ -10,13 +10,14 @@ public class CameraOneRotator : MonoBehaviour {
     [SerializeField] private float moveSpeed;
     [SerializeField] private GameObject playerModel;
     [SerializeField] private GameObject wall;
-    [SerializeField] private GameObject[] rotateTriggers;
+    [SerializeField] private GameObject[] rotateTriggers;    //Triggers that cause tower to rotate
+    [SerializeField] private GameObject[] wallTriggers;     //Triggers that pop up invisible wall behind player
     [SerializeField] private Transform floorSpawn;
 
     //Change these if the tower is scaled
     private static int camPosHorizontal = 45;
-    private static int camPosVertical   = 7;
-    private static int camRotationX     = 10;
+    private static int camPosVertical   = 20;
+    private static int camRotationX     = 5;
     private static int camRotationY     = 0;
     private static int numFloors = 10;
 
@@ -48,7 +49,7 @@ public class CameraOneRotator : MonoBehaviour {
     {
         Vector3 wallPos = wall.transform.position;
         Quaternion wallRot = wall.transform.rotation;
-        float wallY = wall.transform.position.y + 10 * (floor - 1);
+        float wallY = wall.transform.position.y + 20 * (floor - 1);
 
         switch (other.tag)
         {
@@ -62,6 +63,7 @@ public class CameraOneRotator : MonoBehaviour {
                 StartMove(basePositions[3], rotations[3], 4);
                 break;
             case "Trigger4":
+                Debug.Log("Move up");
                 if (floor < numFloors)
                 {
                     floor++;
@@ -75,17 +77,17 @@ public class CameraOneRotator : MonoBehaviour {
                     break;
                 }
             case "Wall1":
-                wallPos = new Vector3(rotateTriggers[0].transform.position.x, wallY, rotateTriggers[0].transform.position.z + 6);
-                wallRot = Quaternion.Euler(wall.transform.rotation.x, wall.transform.rotation.y + 90, wall.transform.rotation.z);
+                wallPos = new Vector3(wallTriggers[0].transform.position.x, wallY, wallTriggers[0].transform.position.z - 2);
+                wallRot = Quaternion.Euler(wall.transform.rotation.x, wall.transform.rotation.y, wall.transform.rotation.z);
                 Instantiate(wall, wallPos, wallRot);
                 break;
             case "Wall2":
-                wallPos = new Vector3(rotateTriggers[1].transform.position.x - 5, wallY, rotateTriggers[1].transform.position.z);
+                wallPos = new Vector3(wallTriggers[1].transform.position.x + 0.5f, wallY, wallTriggers[1].transform.position.z);
                 Instantiate(wall, wallPos, wallRot);
                 break;
             case "Wall3":
-                wallPos = new Vector3(rotateTriggers[2].transform.position.x, wallY, rotateTriggers[1].transform.position.z - 5);
-                wallRot = Quaternion.Euler(wall.transform.rotation.x, wall.transform.rotation.y + 90, wall.transform.rotation.z);
+                wallPos = new Vector3(wallTriggers[2].transform.position.x, wallY, wallTriggers[2].transform.position.z + 2);
+                wallRot = Quaternion.Euler(wall.transform.rotation.x, wall.transform.rotation.y, wall.transform.rotation.z);
                 Instantiate(wall, wallPos, wallRot);
                 break;
         }
@@ -127,7 +129,7 @@ public class CameraOneRotator : MonoBehaviour {
     //TODO: Change this. It's not good. Bugs out sometimes and sends people all the way up. Replace with a Lerp & a ladder? 
     private void MovePlayerUp()
     {
-        this.transform.position = floorSpawn.position + Vector3.up * 10 * (floor - 2);
+        this.transform.position = floorSpawn.position + Vector3.up * 20 * (floor - 2);
     }
 
     //Rotate the player model when you move around the tower


### PR DESCRIPTION
Player now moves up floors the correct amount without skipping or going around in circles. Also updated camera one settings to not follow the player's up/down movement when jumping, only left/right movement.