### PR TITLE
Alex controller

### DIFF
--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -835,7 +835,7 @@ MonoBehaviour:
   m_HorizontalAxis: Horizontal_Menu
   m_VerticalAxis: Vertical_Menu
   m_SubmitButton: Submit_Menu
-  m_CancelButton: Cancel
+  m_CancelButton: Cancel_Menu
   m_InputActionsPerSecond: 10
   m_RepeatDelay: 0.5
   m_ForceModuleActive: 0

--- a/Assets/Scenes/Tower1.unity
+++ b/Assets/Scenes/Tower1.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -517,7 +517,7 @@ MonoBehaviour:
   m_HorizontalAxis: Horizontal_Menu
   m_VerticalAxis: Vertical_Menu
   m_SubmitButton: Submit_Menu
-  m_CancelButton: Cancel
+  m_CancelButton: Cancel_Menu
   m_InputActionsPerSecond: 10
   m_RepeatDelay: 0.5
   m_ForceModuleActive: 0

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -26,7 +26,7 @@ public class GameManager : MonoBehaviour {
 
     private void Update () {
 
-		if(Input.GetButton("Cancel"))
+		if(Input.GetButton("Cancel_Menu"))
         {
             SceneManager.LoadScene("Menu");
         }

--- a/Assets/Scripts/Players/PlayerTwo.cs
+++ b/Assets/Scripts/Players/PlayerTwo.cs
@@ -61,7 +61,7 @@ public class PlayerTwo : MonoBehaviour {
         controller = gameManager.GetControllerTwoState();
         if(controller)
         {
-            if(Mathf.Abs(Input.GetAxisRaw("Horizontal_Joy_2")) > 0.2 || Mathf.Abs(Input.GetAxisRaw("Vertical_Joy_2")) > 0.2)
+            if(Mathf.Abs(Input.GetAxisRaw("Horizontal_Joy_2")) > 0.5f || Mathf.Abs(Input.GetAxisRaw("Vertical_Joy_2")) > 0.5f)
             {
                 controllerCursor.transform.Translate(Input.GetAxisRaw("Horizontal_Joy_2") * controllerCursorSpeed, Input.GetAxisRaw("Vertical_Joy_2") * controllerCursorSpeed, 0);
             }

--- a/Assets/Scripts/Players/PlayerTwo.cs
+++ b/Assets/Scripts/Players/PlayerTwo.cs
@@ -32,11 +32,13 @@ public class PlayerTwo : MonoBehaviour {
 
     private void Start()
     {
+        //Listeners for buttons
         trapButtons[0].onClick.AddListener(OnClickTrap1);
         trapButtons[1].onClick.AddListener(OnClickTrap2);
         trapButtons[2].onClick.AddListener(OnClickTrap3);
         trapButtons[3].onClick.AddListener(OnClickTrap4);
 
+        //Set up trap button navigation & custom cursor if controller is connected
         controller = gameManager.GetControllerTwoState();
         if(controller)
         {
@@ -61,10 +63,12 @@ public class PlayerTwo : MonoBehaviour {
         controller = gameManager.GetControllerTwoState();
         if(controller)
         {
+            //If controller, update controller cursor position to match joystick
             if(Mathf.Abs(Input.GetAxisRaw("Horizontal_Joy_2")) > 0.5f || Mathf.Abs(Input.GetAxisRaw("Vertical_Joy_2")) > 0.5f)
             {
                 controllerCursor.transform.Translate(Input.GetAxisRaw("Horizontal_Joy_2") * controllerCursorSpeed, Input.GetAxisRaw("Vertical_Joy_2") * controllerCursorSpeed, 0);
             }
+            //If controller & they want to place a trap, call raycast function
             if(Input.GetButton("Place_Joy_2") && placeEnabled)
             {
                 RaycastFromCam(true);
@@ -81,10 +85,13 @@ public class PlayerTwo : MonoBehaviour {
 
     //Raycast from camera to center column of tower. Have a ghost trap follow the mouse if a button
     //has been selected, and instantiate one if the tower is clicked.
+    //"clicked" bool should be true if the tower is clicked / the player is trying to actually place a trap down
     private void RaycastFromCam(bool clicked)
     {
         RaycastHit hit;
         Ray ray;
+        
+        //Raycast to custom cursor if controller is connected, otherwise raycast to mouse position
         if (controller)
         {
             ray = cam.ScreenPointToRay(controllerCursor.transform.position);
@@ -96,6 +103,7 @@ public class PlayerTwo : MonoBehaviour {
 
         if (Physics.Raycast(ray, out hit, float.MaxValue, ~LayerMask.NameToLayer("Tower")))
         {
+            //Round hitX, hitY, hitZ to grid based on grid sizes in inspector
             int hitX = Mathf.RoundToInt(hit.point.x / horizontalGridSize) * horizontalGridSize;
             int hitZ = Mathf.RoundToInt(hit.point.z / horizontalGridSize) * horizontalGridSize;
             int hitY = Mathf.RoundToInt(hit.point.y / verticalGridSize) * verticalGridSize;
@@ -104,15 +112,17 @@ public class PlayerTwo : MonoBehaviour {
             Vector3 hitPos = new Vector3(hitX, hitY, hitZ) + hit.normal * 5;
             Quaternion hitRot = Quaternion.identity;
 
+            //Change rotation based on normal from tower 
             if (hit.normal.x == -1 || hit.normal.x == 1)
             {
                 hitRot = Quaternion.Euler(0, 90, 0);
             }
 
 
+            //Change position & rotation of ghost trap to follow mouse if it exists
             if (ghostTrap != null)
             {
-                if(controller)
+                if (controller)
                 {
                     ghostTrap.transform.position = hitPos;
                     ghostTrap.transform.rotation = hitRot;
@@ -124,6 +134,8 @@ public class PlayerTwo : MonoBehaviour {
                 }
             }
 
+
+            //If the player clicked on the tower / if the player is trying to place a trap, and there is enough space nearby, instantiate the trap and destroy the ghost
             if (clicked && CheckNearby(hit.point, widthBetweenTraps, heightBetweenTraps) && CheckFloor(hitPos.y) && trap != null)
             {
                 Instantiate(trap, hitPos, hitRot);
@@ -131,7 +143,8 @@ public class PlayerTwo : MonoBehaviour {
                 Cursor.visible = true;
                 DestroyGhost();
 
-                if(controller)
+                //Set currently selected trap button if there is a controller
+                if (controller)
                 {
                     eventSystem.SetSelectedGameObject(previouslySelected);
                     placeEnabled = false;
@@ -139,7 +152,9 @@ public class PlayerTwo : MonoBehaviour {
             }
         }
         else
+        {
             Cursor.visible = true;
+        }
     }
 
     //Check for nearby platforms/traps to see if it is too close to place a new one.
@@ -203,53 +218,50 @@ public class PlayerTwo : MonoBehaviour {
     {
         Cursor.visible = true;
     }
-
+    
+    //Set cursor not visible when not hovering over button
     public void OnPointerExitSetCursor()
     {
         Cursor.visible = false;
     }
 
+    //Functions that are called when buttons are pressed
     private void OnClickTrap1()
     {
-        trap = traps[0];
-        previouslySelected = trapButtons[0].gameObject;
-        eventSystem.SetSelectedGameObject(null);
-        DestroyGhost();
-        SetGhost();
-        StartCoroutine(EnableInput());
-        
+        ClickButton(0);       
     }
 
     private void OnClickTrap2()
     {
-        trap = traps[1];
-        previouslySelected = trapButtons[1].gameObject;
-        eventSystem.SetSelectedGameObject(null);
-        DestroyGhost();
-        SetGhost();
-        StartCoroutine(EnableInput());
+        ClickButton(1);
     }
 
     private void OnClickTrap3()
     {
-        trap = traps[2];
-        previouslySelected = trapButtons[2].gameObject;
-        eventSystem.SetSelectedGameObject(null);
-        DestroyGhost();
-        SetGhost();
-        StartCoroutine(EnableInput());
+        ClickButton(2);
     }
 
     private void OnClickTrap4()
     {
-        trap = traps[3];
-        previouslySelected = trapButtons[3].gameObject;
+        ClickButton(3);
+    }
+
+    private void ClickButton(int trapNumber)
+    {
+        trap = traps[trapNumber];
+        
+        //Menu selections for controller input
+        previouslySelected = trapButtons[trapNumber].gameObject;
         eventSystem.SetSelectedGameObject(null);
+
         DestroyGhost();
         SetGhost();
+
         StartCoroutine(EnableInput());
     }
 
+    //Make player wait .5 seconds after pressing button to be able to place trap.
+    //Gets rid of controller bug where pressing A to select a trap also immediately places it
     IEnumerator EnableInput()
     {
         yield return new WaitForSeconds(0.5f);

--- a/Assets/Scripts/Players/PlayerTwo.cs
+++ b/Assets/Scripts/Players/PlayerTwo.cs
@@ -79,7 +79,11 @@ public class PlayerTwo : MonoBehaviour {
 
     public void OnClickTower()
     {
-        RaycastFromCam(true);
+        //Only place trap if they are clicking left mouse button (right mouse button is cancel)
+        if(!Input.GetMouseButtonUp(1))
+        {
+            RaycastFromCam(true);
+        }
     }
 
 
@@ -131,6 +135,20 @@ public class PlayerTwo : MonoBehaviour {
                 {
                     ghostTrap.transform.position = hitPos;
                     ghostTrap.transform.rotation = hitRot;
+                }
+
+                //Allow user to cancel the trap they selected
+                if(Input.GetMouseButton(1) || Input.GetButton("Cancel_Joy_2"))
+                {
+                    Cursor.visible = true;
+                    DestroyGhost();
+
+                    //Set currently selected trap button if there is a controller
+                    if (controller)
+                    {
+                        eventSystem.SetSelectedGameObject(previouslySelected);
+                        placeEnabled = false;
+                    }
                 }
             }
 

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -41,8 +41,8 @@ InputManager:
     m_Name: Horizontal_Menu
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: left
-    positiveButton: right
+    negativeButton: joystick 2 button 4
+    positiveButton: joystick 2 button 5
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -214,13 +214,13 @@ InputManager:
     axis: 0
     joyNum: 2
   - serializedVersion: 3
-    m_Name: Cancel
+    m_Name: Cancel_Menu
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
     positiveButton: escape
     altNegativeButton: 
-    altPositiveButton: joystick button 1
+    altPositiveButton: joystick button 7
     gravity: 1000
     dead: 0.001
     sensitivity: 1000

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -41,17 +41,17 @@ InputManager:
     m_Name: Horizontal_Menu
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: joystick 2 button 4
-    positiveButton: joystick 2 button 5
+    negativeButton: 
+    positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3
     dead: 0.001
     sensitivity: 3
     snap: 1
-    invert: 0
+    invert: 1
     type: 2
-    axis: 5
+    axis: 2
     joyNum: 2
   - serializedVersion: 3
     m_Name: Horizontal_Keyboard
@@ -221,6 +221,22 @@ InputManager:
     positiveButton: escape
     altNegativeButton: 
     altPositiveButton: joystick button 7
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: Cancel_Joy_2
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: joystick button 1
     gravity: 1000
     dead: 0.001
     sensitivity: 1000


### PR DESCRIPTION
Changed inputs - new inputs should be:
Player 1 Controller - X to crouch, Start to go to menu
Player 2 Keyboard - Esc to go to menu, Right click to cancel chosen trap
Player 2 Controller - Start to go to menu, B to cancel chosen trap, Triggers instead of d-pad to move between trap buttons; also fixed cursor drift (might have to up the value even more, but need to test with other controllers to see if other joysticks also cause drift)

To Do: 
Player 2 Keyboard - Arrow keys to rotate traps
Player 2 Controller - Bumpers to rotate traps