### PR TITLE
Vertical slice changes

### DIFF
--- a/Assets/Models/Characters/Boy_AnimatingKnockback.fbx.meta
+++ b/Assets/Models/Characters/Boy_AnimatingKnockback.fbx.meta
@@ -260,7 +260,7 @@ ModelImporter:
     - serializedVersion: 16
       name: Armature|Idle
       takeName: Armature|Idle
-      firstFrame: 0
+      firstFrame: 1
       lastFrame: 119
       wrapMode: 0
       orientationOffsetY: 0
@@ -268,8 +268,8 @@ ModelImporter:
       cycleOffset: 0
       loop: 0
       hasAdditiveReferencePose: 0
-      loopTime: 0
-      loopBlend: 0
+      loopTime: 1
+      loopBlend: 1
       loopBlendOrientation: 0
       loopBlendPositionY: 0
       loopBlendPositionXZ: 0
@@ -288,7 +288,7 @@ ModelImporter:
     - serializedVersion: 16
       name: Armature|JumpEnd
       takeName: Armature|JumpEnd
-      firstFrame: 0
+      firstFrame: 1
       lastFrame: 24
       wrapMode: 0
       orientationOffsetY: 0
@@ -323,7 +323,7 @@ ModelImporter:
     - serializedVersion: 16
       name: Armature|JumpIdle
       takeName: Armature|JumpIdle
-      firstFrame: 0
+      firstFrame: 1
       lastFrame: 12
       wrapMode: 0
       orientationOffsetY: 0
@@ -351,7 +351,7 @@ ModelImporter:
     - serializedVersion: 16
       name: Armature|JumpStart
       takeName: Armature|JumpStart
-      firstFrame: 0
+      firstFrame: 1
       lastFrame: 24
       wrapMode: 0
       orientationOffsetY: 0
@@ -359,8 +359,8 @@ ModelImporter:
       cycleOffset: 0
       loop: 0
       hasAdditiveReferencePose: 0
-      loopTime: 0
-      loopBlend: 0
+      loopTime: 1
+      loopBlend: 1
       loopBlendOrientation: 0
       loopBlendPositionY: 0
       loopBlendPositionXZ: 0
@@ -414,7 +414,7 @@ ModelImporter:
     - serializedVersion: 16
       name: Armature|Run
       takeName: Armature|Run
-      firstFrame: 0
+      firstFrame: 1
       lastFrame: 45
       wrapMode: 0
       orientationOffsetY: 0
@@ -422,8 +422,8 @@ ModelImporter:
       cycleOffset: 0
       loop: 0
       hasAdditiveReferencePose: 0
-      loopTime: 0
-      loopBlend: 0
+      loopTime: 1
+      loopBlend: 1
       loopBlendOrientation: 0
       loopBlendPositionY: 0
       loopBlendPositionXZ: 0
@@ -463,7 +463,7 @@ ModelImporter:
     - serializedVersion: 16
       name: Armature|Walk
       takeName: Armature|Walk
-      firstFrame: 0
+      firstFrame: 1
       lastFrame: 60
       wrapMode: 0
       orientationOffsetY: 0
@@ -471,8 +471,8 @@ ModelImporter:
       cycleOffset: 0
       loop: 0
       hasAdditiveReferencePose: 0
-      loopTime: 0
-      loopBlend: 0
+      loopTime: 1
+      loopBlend: 1
       loopBlendOrientation: 0
       loopBlendPositionY: 0
       loopBlendPositionXZ: 0

--- a/Assets/Prefabs/Rising.prefab
+++ b/Assets/Prefabs/Rising.prefab
@@ -399,4 +399,4 @@ MonoBehaviour:
   leftWall: {fileID: 1859898805356856}
   botWall: {fileID: 1223758810322888}
   topWall: {fileID: 1017661876928618}
-  yMov: 0.1
+  yMov: 0.025

--- a/Assets/Scenes/Tower1_Platforms.unity
+++ b/Assets/Scenes/Tower1_Platforms.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.7524489, g: 0.7763308, b: 0.5577417, a: 1}
+  m_IndirectSpecularColor: {r: 0.3731193, g: 0.38073996, b: 0.35872698, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -43103,21 +43103,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 36
       objectReference: {fileID: 0}
-    - target: {fileID: 114539353123675248, guid: 9470e081546a3ba49bf17ad1e808bc85,
-        type: 2}
-      propertyPath: yMov
-      value: 0.025
-      objectReference: {fileID: 0}
-    - target: {fileID: 23102453888433930, guid: 9470e081546a3ba49bf17ad1e808bc85,
-        type: 2}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 72b17bfbc79f0154a99c532f5b105391, type: 2}
-    - target: {fileID: 23796302738638984, guid: 9470e081546a3ba49bf17ad1e808bc85,
-        type: 2}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 72b17bfbc79f0154a99c532f5b105391, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9470e081546a3ba49bf17ad1e808bc85, type: 2}
   m_IsPrefabAsset: 0

--- a/Assets/Scripts/Cameras/CameraTwoRotator.cs
+++ b/Assets/Scripts/Cameras/CameraTwoRotator.cs
@@ -53,7 +53,7 @@ public class CameraTwoRotator : MonoBehaviour {
     { 
         if (moveEnabled)
         {
-            if (Input.GetButton("Submit_Joy_2") && !pause.GameIsPaused)
+            if (Input.GetButtonDown("Submit_Joy_2") && !pause.GameIsPaused)
             {
                 moveEnabled = false;
 

--- a/Assets/Scripts/Players/CastSpell.cs
+++ b/Assets/Scripts/Players/CastSpell.cs
@@ -17,7 +17,7 @@ public class CastSpell : MonoBehaviour {
     private float spellSpeed;
 
     [SerializeField] private int queueSize = 7;
-    public List<GameObject> queue { get; private set; }
+    public GameObject[] queue { get; private set; }
     [SerializeField] private GameObject spellQueue;
     private int queueIndex;
 
@@ -44,7 +44,7 @@ public class CastSpell : MonoBehaviour {
     void Start()
     {
         active = true;
-        queue = new List<GameObject>();
+        queue = new GameObject[queueSize];
         pause = gameManager.GetComponent<PauseMenu>();
         //Handle cursor or set buttons if controller connected
         p2Controller = gameManager.GetComponent<CheckControllers>().GetControllerTwoState();
@@ -80,9 +80,7 @@ public class CastSpell : MonoBehaviour {
 
         if (Input.GetButtonDown("Submit_Joy_2") && !pause.GameIsPaused)
         {
-            DestroyTarget();
             //For testing purposes currently
-            ClearSpellQueue();
             CreateSpellQueue();
             if(active)
             {
@@ -95,6 +93,7 @@ public class CastSpell : MonoBehaviour {
             DestroyTarget();
             SwitchQueue();
         }
+
     }
 
     void FixedUpdate()
@@ -212,7 +211,7 @@ public class CastSpell : MonoBehaviour {
                 if (p2Controller)
                 {
                     //eventSystem.SetSelectedGameObject(previouslySelected);
-                    for (int i = queue.Count - 1; i >= 0; i--)
+                    for (int i = queue.Length - 1; i >= 0; i--)
                     {
                         if (queue[i].activeInHierarchy)
                         {
@@ -272,7 +271,7 @@ public class CastSpell : MonoBehaviour {
                         if(active)
                         {
                             bool buttonSet = false;
-                            for(int i = 0; i < queue.Count; i++)
+                            for(int i = 0; i < queue.Length; i++)
                             {
                                 if(queue[i].activeInHierarchy && !buttonSet)
                                 {
@@ -324,38 +323,46 @@ public class CastSpell : MonoBehaviour {
     {
         for (int i = 0; i < queueSize; i++)
         {
-            int random = 0; //Random.Range(0, spellButtons.Length);
-            GameObject newSpell = Instantiate(spellButtons[random], new Vector3(-108f + 40f * i, 20f, 0), Quaternion.identity) as GameObject;
-            newSpell.transform.SetParent(spellQueue.transform, false);
-
-
-            //Add click listeners for all trap buttons
-            newSpell.GetComponent<Button>().onClick.AddListener(() => OnClickSpell(random));
-            newSpell.GetComponent<ButtonIndex>().ButtonIndexing(i);
-            newSpell.GetComponent<Button>().onClick.AddListener(() => GetIndex(newSpell));
-
-            queue.Add(newSpell);
-
-            if (active == false)
+            if (queue[i] == null)
             {
-                queue[i].GetComponent<Button>().interactable = false;
+                int random = 0; //Random.Range(0, spellButtons.Length);
+                GameObject newSpell = Instantiate(spellButtons[random], new Vector3(-108f + 40f * i, 20f, 0), Quaternion.identity) as GameObject;
+                newSpell.transform.SetParent(spellQueue.transform, false);
+
+
+                //Add click listeners for all trap buttons
+                newSpell.GetComponent<Button>().onClick.AddListener(() => OnClickSpell(random));
+                newSpell.GetComponent<ButtonIndex>().ButtonIndexing(i);
+                newSpell.GetComponent<Button>().onClick.AddListener(() => GetIndex(newSpell));
+
+                queue[i] = newSpell;
+
+                if (active == false)
+                {
+                    queue[i].GetComponent<Button>().interactable = false;
+                }
+                return;
             }
         }
-
     }
 
-    private void ClearSpellQueue()
+    /*private void ClearSpellQueue()
     {
-        for (int i = 0; i < queue.Count; i++)
+        for (int i = 0; i < queue.Length; i++)
         {
-            Destroy(queue[i]);
+            if (!queue[i].activeSelf)
+            {
+               Destroy(queue[i]);
+            }
         }
-        queue.Clear();
-    }
+    }*/
 
     private void ClearButton()
     {
-        queue[queueIndex].SetActive(false);
+        // queue[queueIndex].SetActive(false);
+        Destroy(queue[queueIndex]);
+        queue[queueIndex] = null;
+
     }
 
     //Make player wait .5 seconds after pressing button to be able to place trap.
@@ -395,9 +402,12 @@ public class CastSpell : MonoBehaviour {
         {
             spellQueue.transform.SetAsFirstSibling();
             spellQueue.transform.position += new Vector3(15f, 15f, 0);
-            for (int i = 0; i < queue.Count; i++)
+            for (int i = 0; i < queue.Length; i++)
             {
-                queue[i].GetComponent<Button>().interactable = false;
+                if (queue[i] != null)
+                {
+                    queue[i].GetComponent<Button>().interactable = false;
+                }
             }
         }
 
@@ -406,14 +416,18 @@ public class CastSpell : MonoBehaviour {
             bool buttonSet = false;
             spellQueue.transform.SetAsLastSibling();
             spellQueue.transform.position -= new Vector3(15f, 15f, 0);
-            for (int i = 0; i < queue.Count; i++)
+            for (int i = 0; i < queue.Length; i++)
             {
-                queue[i].GetComponent<Button>().interactable = true;
-
-                if (queue[i].activeInHierarchy && !buttonSet)
+                if (queue[i] != null)
                 {
-                    eventSystem.SetSelectedGameObject(queue[i]);
-                    buttonSet = true;
+                    queue[i].GetComponent<Button>().interactable = true;
+
+
+                    if (queue[i].activeInHierarchy && !buttonSet)
+                    {
+                        eventSystem.SetSelectedGameObject(queue[i]);
+                        buttonSet = true;
+                    }
                 }
             }
         }

--- a/Assets/Scripts/Players/CastSpell.cs
+++ b/Assets/Scripts/Players/CastSpell.cs
@@ -325,7 +325,7 @@ public class CastSpell : MonoBehaviour {
         for (int i = 0; i < queueSize; i++)
         {
             int random = 0; //Random.Range(0, spellButtons.Length);
-            GameObject newSpell = Instantiate(spellButtons[random], new Vector3(-115f + 40f * i, 15f, 0), Quaternion.identity) as GameObject;
+            GameObject newSpell = Instantiate(spellButtons[random], new Vector3(-108f + 40f * i, 20f, 0), Quaternion.identity) as GameObject;
             newSpell.transform.SetParent(spellQueue.transform, false);
 
 
@@ -394,7 +394,7 @@ public class CastSpell : MonoBehaviour {
         if (active == true)
         {
             spellQueue.transform.SetAsFirstSibling();
-            spellQueue.transform.position += new Vector3(35f, 35f, 0);
+            spellQueue.transform.position += new Vector3(15f, 15f, 0);
             for (int i = 0; i < queue.Count; i++)
             {
                 queue[i].GetComponent<Button>().interactable = false;
@@ -405,7 +405,7 @@ public class CastSpell : MonoBehaviour {
         {
             bool buttonSet = false;
             spellQueue.transform.SetAsLastSibling();
-            spellQueue.transform.position -= new Vector3(35f, 35f, 0);
+            spellQueue.transform.position -= new Vector3(15f, 15f, 0);
             for (int i = 0; i < queue.Count; i++)
             {
                 queue[i].GetComponent<Button>().interactable = true;

--- a/Assets/Scripts/Players/CastSpell.cs
+++ b/Assets/Scripts/Players/CastSpell.cs
@@ -80,6 +80,7 @@ public class CastSpell : MonoBehaviour {
 
         if (Input.GetButtonDown("Submit_Joy_2") && !pause.GameIsPaused)
         {
+            DestroyTarget();
             //For testing purposes currently
             CreateSpellQueue();
             if(active)
@@ -181,22 +182,22 @@ public class CastSpell : MonoBehaviour {
                     switch (PlayerOneState)
                     {
                         case 1:
-                            castedSpell = spell.InstantiateSpell(50, playerOne.GetComponent<PlayerOneMovement>().transform.position.y, -42);
+                            castedSpell = spell.InstantiateSpell(50, playerOne.GetComponent<PlayerOneMovement>().transform.position.y + 1.5f, -42);
                             movementVector = new Vector3(-spellSpeed, 0, 0);
                             rb = castedSpell.GetComponent<Rigidbody>();
                             break;
                         case 2:
-                            castedSpell = spell.InstantiateSpell(42, playerOne.GetComponent<PlayerOneMovement>().transform.position.y, 50);
+                            castedSpell = spell.InstantiateSpell(42, playerOne.GetComponent<PlayerOneMovement>().transform.position.y + 1.5f, 50);
                             movementVector = new Vector3(0, 0, -spellSpeed);
                             rb = castedSpell.GetComponent<Rigidbody>();
                             break;
                         case 3:
-                            castedSpell = spell.InstantiateSpell(-50, playerOne.GetComponent<PlayerOneMovement>().transform.position.y, 42);
+                            castedSpell = spell.InstantiateSpell(-50, playerOne.GetComponent<PlayerOneMovement>().transform.position.y + 1.5f, 42);
                             movementVector = new Vector3(spellSpeed, 0, 0);
                             rb = castedSpell.GetComponent<Rigidbody>();
                             break;
                         case 4:
-                            castedSpell = spell.InstantiateSpell(-42, playerOne.GetComponent<PlayerOneMovement>().transform.position.y, -50);
+                            castedSpell = spell.InstantiateSpell(-42, playerOne.GetComponent<PlayerOneMovement>().transform.position.y + 1.5f, -50);
                             movementVector = new Vector3(0, 0, spellSpeed);
                             rb = castedSpell.GetComponent<Rigidbody>();
                             break;

--- a/Assets/Scripts/Players/PlaceTrap.cs
+++ b/Assets/Scripts/Players/PlaceTrap.cs
@@ -442,7 +442,7 @@ public class PlaceTrap : MonoBehaviour {
         for(int i = 0; i < queueSize; i++)
         {
             int random = Random.Range(0, trapButtons.Length);
-            GameObject newTrap = Instantiate(trapButtons[random], new Vector3 (-140f + 40f*i, -10f, 0), Quaternion.identity) as GameObject;
+            GameObject newTrap = Instantiate(trapButtons[random], new Vector3 (-140f + 40f*i, -11f, 0), Quaternion.identity) as GameObject;
             newTrap.transform.SetParent(trapQueue.transform, false);
 
             //Add click listeners for all trap buttons

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -78,7 +78,20 @@ public class PlayerOneMovement : MonoBehaviour {
             case 1:
                 movementVector = new Vector3(inputAxis * speed * Time.deltaTime, rb.velocity.y, 0);
                 //Debug.Log(movementVector);
-                animator.SetFloat("Velocity", rb.velocity.x);
+                if (inputAxis > 0)
+                {
+                    transform.eulerAngles = new Vector3(0, 90, 0);
+                    animator.SetFloat("Velocity", rb.velocity.x);
+                }
+                else if (inputAxis < 0)
+                {
+                    transform.eulerAngles = new Vector3(0, 270, 0);
+                    animator.SetFloat("Velocity", -rb.velocity.x);
+                }
+                else
+                {
+                    animator.SetFloat("Velocity", rb.velocity.x);
+                }
                 rb.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionZ;
                 break;
             case 2:

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -96,17 +96,56 @@ public class PlayerOneMovement : MonoBehaviour {
                 break;
             case 2:
                 movementVector = new Vector3(0, rb.velocity.y, inputAxis * speed * Time.deltaTime);
-                animator.SetFloat("Velocity", rb.velocity.z);
+                if (inputAxis > 0)
+                {
+                    transform.eulerAngles = new Vector3(0, 0, 0);
+                    animator.SetFloat("Velocity", rb.velocity.z);
+                }
+                else if (inputAxis < 0)
+                {
+                    transform.eulerAngles = new Vector3(0, 180, 0);
+                    animator.SetFloat("Velocity", -rb.velocity.z);
+                }
+                else
+                {
+                    animator.SetFloat("Velocity", -rb.velocity.z);
+                }
                 rb.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionX;
                 break;
             case 3:
                 movementVector = new Vector3(-inputAxis * speed * Time.deltaTime, rb.velocity.y, 0);
-                animator.SetFloat("Velocity", -rb.velocity.x);
+                if (inputAxis > 0)
+                {
+                    transform.eulerAngles = new Vector3(0, 270, 0);
+                    animator.SetFloat("Velocity", -rb.velocity.x);
+                }
+                else if (inputAxis < 0)
+                {
+                    transform.eulerAngles = new Vector3(0, 90, 0);
+                    animator.SetFloat("Velocity", rb.velocity.x);
+                }
+                else
+                {
+                    animator.SetFloat("Velocity", -rb.velocity.x);
+                }
                 rb.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionZ;
                 break;
             case 4:
                 movementVector = new Vector3(0, rb.velocity.y, -inputAxis * speed * Time.deltaTime);
-                animator.SetFloat("Velocity", -rb.velocity.z);
+                if (inputAxis > 0)
+                {
+                    transform.eulerAngles = new Vector3(0, 180, 0);
+                    animator.SetFloat("Velocity", -rb.velocity.z);
+                }
+                else if (inputAxis < 0)
+                {
+                    transform.eulerAngles = new Vector3(0, 0, 0);
+                    animator.SetFloat("Velocity", rb.velocity.z);
+                }
+                else
+                {
+                    animator.SetFloat("Velocity", -rb.velocity.z);
+                }
                 rb.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionX;
                 break;
         }

--- a/Assets/Scripts/Rise.cs
+++ b/Assets/Scripts/Rise.cs
@@ -11,7 +11,7 @@ public class Rise : MonoBehaviour {
 
     //For speed of vines
     private float targetPosition = 43f;
-    private float targetSize = 87f;
+    private float targetSize = 89f;
     private float currentPosition;
     private float currentSize;
     private float position;
@@ -30,8 +30,8 @@ public class Rise : MonoBehaviour {
         time = 0;
         currentPosition = rightWall.transform.position.x;
         currentSize = rightWall.transform.localScale.z;
-        position = (currentPosition - targetPosition) / 30f;
-        scale = (currentSize - targetSize) / 30f;
+        position = (currentPosition - targetPosition) / 60f;
+        scale = (currentSize - targetSize) / 60f;
 	}
 	
 	// Update is called once per frame
@@ -49,13 +49,13 @@ public class Rise : MonoBehaviour {
         }
 
         //Vines begin to move in over a certain period of time
-        if (time >= 11f && time <= 41f)
+        if (time >= 11f && time <= 71f)
         {
             moveIn();
         }
 
         //Vines crawl up until tower height is reached
-        if (time >= 41f && rightWall.transform.localScale.y <= 400)
+        if (time >= 71f && rightWall.transform.localScale.y <= 500)
         {
             moveUp();
         }

--- a/Assets/Scripts/Traps/Projectile.cs
+++ b/Assets/Scripts/Traps/Projectile.cs
@@ -10,12 +10,14 @@ public class Projectile : MonoBehaviour {
 
 	private bool hit = false;
 	private GameObject player = null;
+    private Renderer[] child;
 
 	// Use this for initialization
 	void Start () {
 		trapBase = GetComponent<TrapBase>();
 		Destroy(gameObject, 5.0f);
-	}
+        child = GetComponentsInChildren<Renderer>();
+    }
 
 	void FixedUpdate(){
 		if (player != null)
@@ -38,11 +40,19 @@ public class Projectile : MonoBehaviour {
 		if(col.gameObject.tag == "Player"){
 			player = col.gameObject;
 			hit = true;
-            GetComponent<MeshRenderer>().enabled = false;
-		}
+            Unrender();
+
+        }
 		else if(col.gameObject.tag == "Boundary" || col.gameObject.tag == "Platform"){
-            GetComponent<MeshRenderer>().enabled = false;
-            //Destroy(gameObject);
+            Unrender();
         }
 	}
+
+    private void Unrender()
+    {
+        foreach(Renderer r in child)
+        {
+            r.enabled = false;
+        }
+    }
 }

--- a/Assets/Scripts/Traps/Projectile.cs
+++ b/Assets/Scripts/Traps/Projectile.cs
@@ -45,6 +45,7 @@ public class Projectile : MonoBehaviour {
         }
 		else if(col.gameObject.tag == "Boundary" || col.gameObject.tag == "Platform"){
             Unrender();
+            StartCoroutine(Death(stunDuration));
         }
 	}
 
@@ -54,5 +55,12 @@ public class Projectile : MonoBehaviour {
         {
             r.enabled = false;
         }
+    }
+
+    private IEnumerator Death(float stunDuration)
+    {
+        yield return new WaitForSeconds(stunDuration + 2f);
+
+        Destroy(this.gameObject);
     }
 }

--- a/Assets/Scripts/UI/PauseMenu.cs
+++ b/Assets/Scripts/UI/PauseMenu.cs
@@ -53,7 +53,7 @@ public class PauseMenu : MonoBehaviour {
 	public void Resume(){
 		pauseMenuUI.SetActive(false);
         bool buttonSet = false;
-        for (int i = 0; i < cs.queue.Count; i++)
+        for (int i = 0; i < cs.queue.Length; i++)
         {
             if(cs.active) cs.queue[i].GetComponent<Button>().interactable = true;
             if(cs.active && cs.queue[i].activeInHierarchy && !buttonSet)
@@ -80,7 +80,7 @@ public class PauseMenu : MonoBehaviour {
 		pauseMenuUI.SetActive(true);
         pauseMenuUI.transform.SetAsLastSibling();
 
-        for(int i = 0; i < cs.queue.Count; i++)
+        for(int i = 0; i < cs.queue.Length; i++)
         {
             cs.queue[i].GetComponent<Button>().interactable = false;
         }


### PR DESCRIPTION
Made projectile invisible when colliding with player/platform/boundary.

If projectile collides with a platform/boundary, it destroys it self after its stun duration + 2 seconds to ensure player can never get infinitely stunned.

Repositioned both queues for a better asethetic.

Vines take 60 seconds to close in on tower instead of 30 seconds.

Spell queue gives one spell per face now.

Holding enter will only rotate tower once.

Moved slow spell up to better hit player.

Fixed animation going into T-poses.

Player now faces direction he moves in on all faces.