### PR TITLE
Delete traps bug

### DIFF
--- a/Assets/Prefabs/Players and Cameras/Player 2.prefab
+++ b/Assets/Prefabs/Players and Cameras/Player 2.prefab
@@ -172,7 +172,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
-  m_Volume: 0.3
+  m_Volume: 1
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -347,6 +347,7 @@ MonoBehaviour:
   targeting:
   - {fileID: 1046908235356196, guid: 0ded149890f182d4685b20ceb6c49d1b, type: 2}
   - {fileID: 1424637060701814, guid: e34ed2dd750177e4ba19c7100de1f5df, type: 2}
+  - {fileID: 1424637060701814, guid: 5d4a7e903769c9245a97278745db2832, type: 2}
   placeEnabled: 0
 --- !u!136 &136189357046121884
 CapsuleCollider:

--- a/Assets/Prefabs/Spells/SlowTarget.prefab
+++ b/Assets/Prefabs/Spells/SlowTarget.prefab
@@ -114,7 +114,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
-  m_Volume: 0.17
+  m_Volume: 0.5
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/Assets/Prefabs/Traps/ArrowTrap.prefab
+++ b/Assets/Prefabs/Traps/ArrowTrap.prefab
@@ -1410,7 +1410,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
-  m_Volume: 0.04
+  m_Volume: 1
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -1026,7 +1026,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: b9476bb84c2ea594e82dc6a745d59713, type: 3}
   m_PlayOnAwake: 1
-  m_Volume: 0.1
+  m_Volume: 1
   m_Pitch: 1
   Loop: 1
   Mute: 0

--- a/Assets/Scenes/Tower1.unity
+++ b/Assets/Scenes/Tower1.unity
@@ -352,7 +352,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.230095
+      value: -80.18274
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalRotation.x
@@ -1375,12 +1375,6 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 378012454}
   m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
---- !u!114 &378012456 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 114958971114074792, guid: c130ae0761b27334089036b39347c937,
-    type: 2}
-  m_PrefabInternal: {fileID: 378012454}
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
 --- !u!114 &378012457 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114375043952648214, guid: c130ae0761b27334089036b39347c937,
@@ -2379,11 +2373,12 @@ MonoBehaviour:
   pauseButtons:
   - {fileID: 1566570390}
   - {fileID: 378012457}
-  - {fileID: 378012456}
+  - {fileID: 0}
   - {fileID: 378012455}
   controlsCanvas: {fileID: 1241385922}
   resumeButton: {fileID: 1566570390}
   playerTwo: {fileID: 1027381073}
+  playerOne: {fileID: 1338709831}
   es: {fileID: 1160000097}
 --- !u!114 &1016487810
 MonoBehaviour:
@@ -4339,7 +4334,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.230095
+      value: -80.18274
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalRotation.x

--- a/Assets/Scenes/Tutorial.unity
+++ b/Assets/Scenes/Tutorial.unity
@@ -208,7 +208,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.230095
+      value: -80.19011
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalRotation.x
@@ -1830,7 +1830,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 2d28081c1f5997a418fe1dfe2003123b, type: 3}
   m_PlayOnAwake: 1
-  m_Volume: 0.05
+  m_Volume: 0.5
   m_Pitch: 1
   Loop: 1
   Mute: 0
@@ -5124,7 +5124,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.230095
+      value: -80.19011
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalRotation.x

--- a/Assets/Scripts/Destroy.cs
+++ b/Assets/Scripts/Destroy.cs
@@ -21,7 +21,8 @@ public class Destroy : MonoBehaviour {
 
     private void Update()
     {
-        if(bottomPlayer.GetFloor() > floor || (bottomPlayer.GetFloor() == floor && bottomPlayer.GetState() > face))
+        if((bottomPlayer.GetFloor() > floor || (bottomPlayer.GetFloor() == floor && bottomPlayer.GetState() > face)) &&
+            (topPlayer.GetFloor() > floor || (topPlayer.GetFloor() == floor && topPlayer.GetState() > face)))
         {
             Component[] components = GetComponents<Component>();
             Component[] childComponents = GetComponentsInChildren<Component>();

--- a/Assets/Scripts/Players/CastSpell.cs
+++ b/Assets/Scripts/Players/CastSpell.cs
@@ -391,13 +391,14 @@ public class CastSpell : MonoBehaviour {
                     }
 
                 }
+                
+                //Cancel the spell
+                //if (Input.GetMouseButton(1) || Input.GetButton("Cancel_Joy_2"))
+                //{
+                //    DestroyTarget();
 
-                if (Input.GetMouseButton(1) || Input.GetButton("Cancel_Joy_2"))
-                {
-                    DestroyTarget();
-
-                    SetSelectedButton();
-                }
+                //    SetSelectedButton();
+                //}
             }
         }
     }

--- a/Assets/Scripts/Players/CastSpell.cs
+++ b/Assets/Scripts/Players/CastSpell.cs
@@ -56,6 +56,7 @@ public class CastSpell : MonoBehaviour {
     //Controller Stuff
     private bool p2Controller;
     public bool placeEnabled;
+    public bool InputEnabled = true;
 
     
 
@@ -77,6 +78,7 @@ public class CastSpell : MonoBehaviour {
         //Handle cursor or set buttons if controller connected
         p2Controller = gameManager.GetComponent<CheckControllers>().GetControllerTwoState();
         placeEnabled = false;
+        InputEnabled = true;
     }
 
 
@@ -88,7 +90,7 @@ public class CastSpell : MonoBehaviour {
         //CONTROLLER ONLY Spell Casting Check
         if (p2Controller && !pause.GameIsPaused)
         {
-            if (Input.GetButtonDown("Place_Joy_2") && placeEnabled && spellTarget != null)
+            if (Input.GetButtonDown("Place_Joy_2") && placeEnabled && InputEnabled && spellTarget != null)
             {
                 SpellCast();
             }
@@ -512,8 +514,14 @@ public class CastSpell : MonoBehaviour {
     IEnumerator EnableInput()
     {
         yield return new WaitForSeconds(0.5f);
-      //  resetEnabled = true;
         placeEnabled = true;
+    }
+
+    //Called from pause script to re-enable input after pressing "Resume"
+    public IEnumerator ResumeInput()
+    {
+        yield return new WaitForSeconds(0.5f);
+        InputEnabled = true;
     }
 
     //Start a cooldown on the button pressed. Needs current button position and queue index to replace.
@@ -574,45 +582,4 @@ public class CastSpell : MonoBehaviour {
         }
         return null;
     }
-
-    //---------------------------------------Not needed if we aren't swapping back and forth.
-    //private void SwitchQueue()
-    //{
-    //    if (active == true)
-    //    {
-    //        spellQueue.transform.SetAsFirstSibling();
-    //        spellQueue.transform.position += new Vector3(15f, 15f, 0);
-    //        for (int i = 0; i < queue.Length; i++)
-    //        {
-    //            if (queue[i] != null)
-    //            {
-    //                queue[i].GetComponent<Button>().interactable = false;
-    //            }
-    //        }
-    //    }
-
-    //    if (active == false)
-    //    {
-    //        controllerCursor.transform.position = new Vector3(Screen.width / 2, Screen.height / 2 - cursorDistFromCenter, 0);
-    //        GetComponent<MoveControllerCursor>().MovingTraps = false;
-    //        bool buttonSet = false;
-    //        spellQueue.transform.SetAsLastSibling();
-    //        spellQueue.transform.position -= new Vector3(15f, 15f, 0);
-    //        for (int i = 0; i < queue.Length; i++)
-    //        {
-    //            if (queue[i] != null)
-    //            {
-    //                queue[i].GetComponent<Button>().interactable = true;
-
-
-    //                if (queue[i].activeInHierarchy && !buttonSet)
-    //                {
-    //                    eventSystem.SetSelectedGameObject(queue[i]);
-    //                    buttonSet = true;
-    //                }
-    //            }
-    //        }
-    //    }
-    //    active = !active;
-    //}
 }

--- a/Assets/Scripts/Players/MoveControllerCursor.cs
+++ b/Assets/Scripts/Players/MoveControllerCursor.cs
@@ -54,8 +54,13 @@ public class MoveControllerCursor : MonoBehaviour {
 
         if (p2Controller && !pause.GameIsPaused && MovingTraps)
         {
+            float horizontalInput, verticalInput;
+            horizontalInput = Input.GetAxisRaw("Horizontal_Joy_2") + Input.GetAxisRaw("Horizontal_Dpad");
+            verticalInput = Input.GetAxisRaw("Vertical_Joy_2") + Input.GetAxisRaw("Vertical_Dpad");
+
             Vector3 cursorPos = controllerCursor.GetComponent<RectTransform>().localPosition;
-            if (Input.GetAxisRaw("Horizontal_Joy_2") > stickSensitivity && cursorHorizontalMove && cursorPos.x < screenWidth)
+
+            if (horizontalInput > stickSensitivity && cursorHorizontalMove && cursorPos.x < screenWidth)
             {
                 controllerCursor.GetComponent<RectTransform>().localPosition += new Vector3(cursorGrid, 0, 0);
                 cursorHorizontalMove = false;
@@ -63,21 +68,21 @@ public class MoveControllerCursor : MonoBehaviour {
 
                 //audioSource.PlayOneShot(spaceSelectionSFX);
             }
-            else if (Input.GetAxisRaw("Horizontal_Joy_2") < -stickSensitivity && cursorHorizontalMove && cursorPos.x > -screenWidth)
+            else if (horizontalInput < -stickSensitivity && cursorHorizontalMove && cursorPos.x > -screenWidth)
             {
                 controllerCursor.GetComponent<RectTransform>().localPosition -= new Vector3(cursorGrid, 0, 0);
                 cursorHorizontalMove = false;
                 StartCoroutine(EnableHorizontalCursorMove());
                 //audioSource.PlayOneShot(spaceSelectionSFX);
             }
-            else if (Input.GetAxisRaw("Vertical_Joy_2") > stickSensitivity && cursorVerticalMove && cursorPos.y < screenHeight)
+            else if (verticalInput > stickSensitivity && cursorVerticalMove && cursorPos.y < screenHeight)
             {
                 controllerCursor.GetComponent<RectTransform>().localPosition += new Vector3(0, cursorGrid, 0);
                 cursorVerticalMove = false;
                 StartCoroutine(EnableVerticalCursorMove());
                // audioSource.PlayOneShot(spaceSelectionSFX);
             }
-            else if (Input.GetAxisRaw("Vertical_Joy_2") < -stickSensitivity && cursorVerticalMove && cursorPos.y > 0)
+            else if (verticalInput < -stickSensitivity && cursorVerticalMove && cursorPos.y > 0)
             {
                 controllerCursor.GetComponent<RectTransform>().localPosition -= new Vector3(0, cursorGrid, 0);
                 cursorVerticalMove = false;
@@ -87,41 +92,46 @@ public class MoveControllerCursor : MonoBehaviour {
         }
         else if (p2Controller && !pause.GameIsPaused && !MovingTraps)
         {
+            float horizontalInput, verticalInput;
+            horizontalInput = Input.GetAxisRaw("Horizontal_Joy_2") + Input.GetAxisRaw("Horizontal_Dpad");
+            verticalInput = Input.GetAxisRaw("Vertical_Joy_2") + Input.GetAxisRaw("Vertical_Dpad");
+
             if (SpellCastDirection == SpellDirection.Instant)
             {
                 Vector3 cursorPos = controllerCursor.GetComponent<RectTransform>().localPosition;
-                if (Input.GetAxisRaw("Vertical_Joy_2") > stickSensitivity && cursorPos.y < -55)
+
+                if (verticalInput > stickSensitivity && cursorPos.y < -55)
                 {
                     Vector3 pos = controllerCursor.transform.localPosition;
                     pos.z = 35;
                     
-                    controllerCursor.transform.Translate(new Vector3(0f, Input.GetAxisRaw("Vertical_Joy_2") * freeRoamSpellSpeed, 0f));
+                    controllerCursor.transform.Translate(new Vector3(0f, verticalInput * freeRoamSpellSpeed, 0f));
                     
                 }
-                if (Input.GetAxisRaw("Vertical_Joy_2") < -stickSensitivity && cursorPos.y > -screenHeight)
+                if (verticalInput < -stickSensitivity && cursorPos.y > -screenHeight)
                 {
                     Vector3 pos = controllerCursor.transform.localPosition;
                     pos.z = 35;
 
-                    controllerCursor.transform.Translate(new Vector3(0f, Input.GetAxisRaw("Vertical_Joy_2") * freeRoamSpellSpeed, 0f));
+                    controllerCursor.transform.Translate(new Vector3(0f, verticalInput * freeRoamSpellSpeed, 0f));
 
                 }
-                if (Input.GetAxisRaw("Horizontal_Joy_2") < -stickSensitivity)
+                if (horizontalInput < -stickSensitivity)
                 {
                     Vector3 pos = controllerCursor.transform.localPosition;
                     pos.z = 35;
                     if(controllerCursor.transform.localPosition.x > -screenWidth)
                     {
-                        controllerCursor.transform.Translate(new Vector3(Input.GetAxisRaw("Horizontal_Joy_2") * freeRoamSpellSpeed, 0f, 0f));
+                        controllerCursor.transform.Translate(new Vector3(horizontalInput * freeRoamSpellSpeed, 0f, 0f));
                     }
                 }
-                if(Input.GetAxisRaw("Horizontal_Joy_2") > stickSensitivity)
+                if(horizontalInput > stickSensitivity)
                 {
                     Vector3 pos = controllerCursor.transform.localPosition;
                     pos.z = 35;
                     if (controllerCursor.transform.localPosition.x < screenWidth)
                     {
-                        controllerCursor.transform.Translate(new Vector3(Input.GetAxisRaw("Horizontal_Joy_2") * freeRoamSpellSpeed, 0f, 0f));
+                        controllerCursor.transform.Translate(new Vector3(horizontalInput * freeRoamSpellSpeed, 0f, 0f));
                     }
                 }
             }
@@ -129,11 +139,11 @@ public class MoveControllerCursor : MonoBehaviour {
             {
 
                 Vector3 cursorPos = controllerCursor.GetComponent<RectTransform>().localPosition;
-                if (Input.GetAxisRaw("Vertical_Joy_2") > stickSensitivity && cursorVerticalMove && cursorPos.y < -55)
+                if (verticalInput > stickSensitivity && cursorVerticalMove && cursorPos.y < -55)
                 {
                     controllerCursor.GetComponent<RectTransform>().localPosition += new Vector3(0, cursorGrid * spellBarSpeedMultiplier, 0);
                 }
-                else if (Input.GetAxisRaw("Vertical_Joy_2") < -stickSensitivity && cursorVerticalMove && cursorPos.y > -screenHeight)
+                else if (verticalInput < -stickSensitivity && cursorVerticalMove && cursorPos.y > -screenHeight)
                 {
                     controllerCursor.GetComponent<RectTransform>().localPosition -= new Vector3(0, cursorGrid * spellBarSpeedMultiplier, 0);
                 }
@@ -141,11 +151,11 @@ public class MoveControllerCursor : MonoBehaviour {
             else if(SpellCastDirection == SpellDirection.Ceiling)
             {
                 Vector3 cursorPos = controllerCursor.GetComponent<RectTransform>().localPosition;
-                if (Input.GetAxisRaw("Horizontal_Joy_2") > stickSensitivity && cursorHorizontalMove && cursorPos.x < screenWidth)
+                if (horizontalInput > stickSensitivity && cursorHorizontalMove && cursorPos.x < screenWidth)
                 {
                     controllerCursor.GetComponent<RectTransform>().localPosition += new Vector3(cursorGrid * spellBarSpeedMultiplier, 0, 0);
                 }
-                else if (Input.GetAxisRaw("Horizontal_Joy_2") < -stickSensitivity && cursorHorizontalMove && cursorPos.x > -screenWidth)
+                else if (horizontalInput < -stickSensitivity && cursorHorizontalMove && cursorPos.x > -screenWidth)
                 {
                     controllerCursor.GetComponent<RectTransform>().localPosition -= new Vector3(cursorGrid * spellBarSpeedMultiplier, 0, 0);
                 }

--- a/Assets/Scripts/Players/PlaceTrap.cs
+++ b/Assets/Scripts/Players/PlaceTrap.cs
@@ -424,12 +424,12 @@ public class PlaceTrap : MonoBehaviour {
                 ghostTrap.transform.position = position;
 
                 //Cancel the trap
-                if ((Input.GetMouseButton(1) || Input.GetButton("Cancel_Joy_2")) && !pause.GameIsPaused)
-                {
-                    DestroyGhost();
-                    placementSquares = null;
-                    SetSelectedButton();
-                }
+                //if ((Input.GetMouseButton(1) || Input.GetButton("Cancel_Joy_2")) && !pause.GameIsPaused)
+                //{
+                //    DestroyGhost();
+                //    placementSquares = null;
+                //    SetSelectedButton();
+                //}
             }
         }
     }

--- a/Assets/Scripts/Players/PlaceTrap.cs
+++ b/Assets/Scripts/Players/PlaceTrap.cs
@@ -57,13 +57,12 @@ public class PlaceTrap : MonoBehaviour {
     
     //Controller Stuff
     private bool p2Controller;
-    private bool placeEnabled;
-
+    public bool InputEnabled = true;
+    private bool resetEnabled = true;
 
 
 
     private int numTimesRotated = 0;
-    private bool resetEnabled = true;
 
 	void Start () {
         //Get references
@@ -81,7 +80,6 @@ public class PlaceTrap : MonoBehaviour {
         //Handle cursor or set buttons if controller connected
         checkControllers = gameManager.GetComponent<CheckControllers>();
         p2Controller = checkControllers.GetControllerTwoState();
-        placeEnabled = true;
 
         if (p2Controller)
         {
@@ -98,7 +96,7 @@ public class PlaceTrap : MonoBehaviour {
         p2Controller = checkControllers.GetControllerTwoState();
         if (p2Controller && !pause.GameIsPaused)
         {
-            if (Input.GetButtonDown("Place_Joy_2") && placeEnabled)
+            if (Input.GetButtonDown("Place_Joy_2") && InputEnabled)
             {
                 MoveGhost();
                 SetTrap();
@@ -568,6 +566,12 @@ public class PlaceTrap : MonoBehaviour {
         resetEnabled = true;
     }
 
+    //Called from pause script to re-enable input after pressing "Resume"
+    public IEnumerator ResumeInput()
+    {
+        yield return new WaitForSeconds(0.5f);
+        InputEnabled = true;
+    }
 
 
     /// --------------------------------------------------------
@@ -639,7 +643,6 @@ public class PlaceTrap : MonoBehaviour {
                         if (cs.queue[i] != null && cs.queue[i].GetComponent<Button>().interactable && cs.queue[i].activeInHierarchy && !buttonSet)
                         {
                             controllerCursor.transform.localPosition = new Vector3(0, -100);
-                            cs.placeEnabled = false;
                             eventSystem.SetSelectedGameObject(cs.queue[i]);
                             buttonSet = true;
                         }
@@ -647,39 +650,6 @@ public class PlaceTrap : MonoBehaviour {
                 }
 
             }
-            //placeEnabled = false;
         }
     }
-
-    //private void SwitchQueue()
-    //{
-    //    if (active == true)
-    //    {
-    //        trapQueue.transform.SetAsFirstSibling();
-    //        trapQueue.transform.position += new Vector3(15f, 15f, 0);
-    //        for (int i = 0; i < queue.Count; i++)
-    //        {
-    //            queue[i].GetComponent<Button>().interactable = false;
-    //        }
-    //    }
-
-    //    if (active == false)
-    //    {
-    //        controllerCursor.transform.position = new Vector3(Screen.width / 2, Screen.height / 2 + cursorDistFromCenter, 0);
-    //        GetComponent<MoveControllerCursor>().MovingTraps = true;
-    //        bool buttonSet = false;
-    //        trapQueue.transform.SetAsLastSibling();
-    //        trapQueue.transform.position -= new Vector3(15f, 15f, 0);
-    //        for (int i = 0; i < queue.Count; i++)
-    //        {
-    //            queue[i].GetComponent<Button>().interactable = true;
-    //            if (queue[i].activeInHierarchy && !buttonSet)
-    //            {
-    //                eventSystem.SetSelectedGameObject(queue[i]);
-    //                buttonSet = true;
-    //            }
-    //        }
-    //    }
-    //    active = !active;
-    //}
 }

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -41,6 +41,7 @@ public class PlayerOneMovement : MonoBehaviour {
 
 
     private CheckControllers checkControllers;
+    private PauseMenu pause;
     private Animator animator;
     private CapsuleCollider col;
     private ParticleSystemRenderer stun;
@@ -51,6 +52,7 @@ public class PlayerOneMovement : MonoBehaviour {
         checkControllers = gameManager.GetComponent<CheckControllers>();
         col = GetComponent<CapsuleCollider>();
         stun = GetComponentInChildren<ParticleSystemRenderer>();
+        pause = gameManager.GetComponent<PauseMenu>();
 
         speed = moveSpeed;
         jumpH = jumpHeight;
@@ -62,7 +64,7 @@ public class PlayerOneMovement : MonoBehaviour {
     {
         camOneState = cam.GetState();
         grounded = GetComponentInChildren<PlayerGrounded>().IsGrounded();
-        if (move == true)
+        if (move == true && !pause.GameIsPaused)
         {
             inputAxis = checkControllers.GetInputAxis();
 
@@ -219,7 +221,7 @@ public class PlayerOneMovement : MonoBehaviour {
 
         cantStandUp = gameObject.GetComponentInChildren<Colliding>().GetCollision();
 
-        Move();
+        if(!pause.GameIsPaused) Move();
     }
 
 

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -21,6 +21,7 @@ public class PlayerOneMovement : MonoBehaviour {
     private bool wallJumping;
     private bool cantStandUp;
     private bool slowed = false;
+    public bool InputEnabled = true;
 
     //Control if player can have input
     private bool move = true;
@@ -64,7 +65,7 @@ public class PlayerOneMovement : MonoBehaviour {
     {
         camOneState = cam.GetState();
         grounded = GetComponentInChildren<PlayerGrounded>().IsGrounded();
-        if (move == true && !pause.GameIsPaused)
+        if (move == true && !pause.GameIsPaused && InputEnabled)
         {
             inputAxis = checkControllers.GetInputAxis();
 
@@ -310,6 +311,13 @@ public class PlayerOneMovement : MonoBehaviour {
         yield return new WaitForSeconds(wallJumpTime);
         wallJumping = false;
         wallJumpVector = Vector3.zero;
+    }
+
+    //Called from pause script to re-enable input after pressing "Resume"
+    public IEnumerator ResumeInput()
+    {
+        yield return new WaitForSeconds(0.5f);
+        InputEnabled = true;
     }
 
     /////////////////////////////////////////////

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -291,7 +291,7 @@ public class PlayerOneMovement : MonoBehaviour {
             RaycastHit hit;
             RaycastHit downHit;
             bool raycastDown = Physics.Raycast(transform.position, -transform.up, out downHit, 1);
-            if (Physics.Raycast(transform.position, transform.forward, out hit, 1) && !raycastDown)
+            if (Physics.Raycast(transform.position, transform.forward, out hit, 1.5f) && !raycastDown)
             {
                 if (hit.transform.tag == "Platform" && Input.GetButtonDown("Jump_Joy_1") && grounded == false && move == true)
                 {

--- a/Assets/Scripts/UI/PauseMenu.cs
+++ b/Assets/Scripts/UI/PauseMenu.cs
@@ -27,7 +27,7 @@ public class PauseMenu : MonoBehaviour {
 
     // Update is called once per frame
     void Update () {
-        if (Input.GetButtonDown("Cancel"))
+        if (Input.GetButtonDown("Start"))
         {
             if (GameIsPaused)
             {
@@ -47,6 +47,11 @@ public class PauseMenu : MonoBehaviour {
                     pauseButtons[i].interactable = true;
                 }
             }
+        }
+
+        if(GameIsPaused && Input.GetButtonDown("Cancel"))
+        {
+            Resume();
         }
 	}
 	

--- a/Assets/Scripts/UI/TutorialController.cs
+++ b/Assets/Scripts/UI/TutorialController.cs
@@ -68,7 +68,7 @@ public class TutorialController : MonoBehaviour
             tip.SetActive(false);
         }
 
-        if (Input.GetButtonDown("Cancel"))
+        if (Input.GetButtonDown("Start"))
         {
             Initiate.Fade("Tower1", Color.black, 2);
         }

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -246,7 +246,7 @@ InputManager:
     axis: 0
     joyNum: 2
   - serializedVersion: 3
-    m_Name: Cancel
+    m_Name: Start
     descriptiveName: Menu Button
     descriptiveNegativeName: 
     negativeButton: 
@@ -262,7 +262,7 @@ InputManager:
     axis: 0
     joyNum: 0
   - serializedVersion: 3
-    m_Name: Cancel_Joy_2
+    m_Name: Cancel
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -38,6 +38,22 @@ InputManager:
     axis: 0
     joyNum: 2
   - serializedVersion: 3
+    m_Name: Horizontal_Dpad
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: a
+    positiveButton: d
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 5
+    joyNum: 2
+  - serializedVersion: 3
     m_Name: Horizontal_Menu
     descriptiveName: 
     descriptiveNegativeName: 
@@ -116,6 +132,22 @@ InputManager:
     invert: 1
     type: 2
     axis: 1
+    joyNum: 2
+  - serializedVersion: 3
+    m_Name: Vertical_Dpad
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: s
+    positiveButton: w
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 6
     joyNum: 2
   - serializedVersion: 3
     m_Name: Vertical_Menu


### PR DESCRIPTION
- traps don't get deleted until both players have passed
- tweaked some audio values 
- fixed some of the pause menu input - won't jump, turn, place traps/spells, etc. while on pause menu anymore
- pause menu also remembers previously selected trap/spell button and returns to that instead of a default now
- fix wall jump so you don't have to be pushing stick to wall jump - slightly more responsive
- add dpad input for top player