### PR TITLE
Trap spell selection fixes

### DIFF
--- a/Assets/Scripts/Players/CastSpell.cs
+++ b/Assets/Scripts/Players/CastSpell.cs
@@ -57,7 +57,7 @@ public class CastSpell : MonoBehaviour {
     private bool p2Controller;
     public bool placeEnabled;
     public bool InputEnabled = true;
-
+    private int previouslySelectedIndex;
     
 
 
@@ -258,11 +258,14 @@ public class CastSpell : MonoBehaviour {
                 }
                 StartCoroutine(StartCooldown(spell.GetComponent<SpellBase>().CooldownTime, queue[queueIndex].transform.localPosition, queueIndex));
 
+                previouslySelectedIndex = queueIndex;
+
                 spell = null;
 
                 ClearButton();
 
                 DestroyTarget();
+
 
                 SetSelectedButton();
             }
@@ -485,7 +488,9 @@ public class CastSpell : MonoBehaviour {
         if (p2Controller)
         {
             bool buttonSet = false;
-            for (int i = queue.Length - 1; i >= 0; i--)
+
+            //Loop over remaining spell queue to see if any are available
+            for (int i = previouslySelectedIndex; i < queue.Length; i++)
             {
                 if (queue[i] != null && queue[i].activeInHierarchy && queue[i].GetComponent<Button>().interactable && !buttonSet)
                 {
@@ -493,6 +498,21 @@ public class CastSpell : MonoBehaviour {
                     buttonSet = true;
                 }
             }
+
+            //Loop over previous of spell queue to see if any are available
+            if(!buttonSet)
+            {
+                for (int i = previouslySelectedIndex; i >= 0; i--)
+                {
+                    if (queue[i] != null && queue[i].activeInHierarchy && queue[i].GetComponent<Button>().interactable && !buttonSet)
+                    {
+                        eventSystem.SetSelectedGameObject(queue[i]);
+                        buttonSet = true;
+                    }
+                }
+            }
+
+            //Loop over traps to set available button
             if (!buttonSet)
             {
                 for (int i = 0; i < pt.queue.Count; i++)

--- a/Assets/Scripts/Players/CastSpell.cs
+++ b/Assets/Scripts/Players/CastSpell.cs
@@ -497,7 +497,7 @@ public class CastSpell : MonoBehaviour {
             {
                 for (int i = 0; i < pt.queue.Count; i++)
                 {
-                    if (pt.queue[i] != null && pt.queue[i].activeInHierarchy && !buttonSet)
+                    if (pt.queue[i] != null && pt.queue[i].activeInHierarchy && !buttonSet && pt.queue[i].GetComponent<Button>().interactable)
                     {
 
                         controllerCursor.transform.localPosition = new Vector3(0, 130);

--- a/Assets/Scripts/Players/PlaceTrap.cs
+++ b/Assets/Scripts/Players/PlaceTrap.cs
@@ -59,7 +59,7 @@ public class PlaceTrap : MonoBehaviour {
     private bool p2Controller;
     public bool InputEnabled = true;
     private bool resetEnabled = true;
-
+    private int previouslySelectedIndex;
 
 
     private int numTimesRotated = 0;
@@ -229,7 +229,8 @@ public class PlaceTrap : MonoBehaviour {
                     audioSource.PlayOneShot(trapPlacementGood);
                     trap.InstantiateTrap(position, ghostTrap.transform.rotation);
                     if (check != null) check.Placed = true;
-                    //if (bases != null) bases.Placed = true;
+                    previouslySelectedIndex = queueIndex;
+
                     ClearButton();
                     trap = null;
                     foreach (SpriteRenderer sr in placementSquares)
@@ -238,7 +239,6 @@ public class PlaceTrap : MonoBehaviour {
                     }
                     placementSquares = null;
                     DestroyGhost();
-
                     SetSelectedButton();
                 }
                 else
@@ -288,20 +288,7 @@ public class PlaceTrap : MonoBehaviour {
     {
         RaycastHit hit;
         Ray ray;
-        //Ray to controller cursor
-        //if (p2Controller && controllerCursor.transform.position.y > Screen.height / 2)
-        //{
-        //    ray = cam.ray
-        //    ray = cam.WorldPointToRay(ghostTrap.transform.position);
-        //    if (Physics.Raycast(ray, out hit, float.MaxValue, ~LayerMask.GetMask("Ignore Raycast")))
-        //    {
-        //        if (hit.transform.tag == "Platform")
-        //        {
-        //            return false;
-        //        }
-        //    }
-        //    else return true;
-        //}
+
         //Ray to mouse cursor
         if (Input.mousePosition.y > Screen.height / 2)
         {
@@ -551,7 +538,6 @@ public class PlaceTrap : MonoBehaviour {
     {
         trap = trapPrefabs[trapNum];
         trapRot = 0;
-//        eventSystem.SetSelectedGameObject(null);
         StartCoroutine(EnableInput());
         DestroyGhost();
         GetComponent<CastSpell>().DestroyTarget();
@@ -629,7 +615,8 @@ public class PlaceTrap : MonoBehaviour {
             if (active)
             {
                 bool buttonSet = false;
-                for (int i = 0; i < queue.Count; i++)
+                //Loop over rest of trap queue
+                for (int i = previouslySelectedIndex; i < queue.Count; i++)
                 {
                     if (queue[i].activeInHierarchy && !buttonSet && queue[i].GetComponent<Button>().interactable)
                     {
@@ -637,6 +624,20 @@ public class PlaceTrap : MonoBehaviour {
                         buttonSet = true;
                     }
                 }
+
+                //Loop over previous trap queue
+                if(!buttonSet)
+                {
+                    for (int i = previouslySelectedIndex; i >= 0; i--)
+                    {
+                        if (queue[i].activeInHierarchy && !buttonSet && queue[i].GetComponent<Button>().interactable)
+                        {
+                            eventSystem.SetSelectedGameObject(queue[i]);
+                            buttonSet = true;
+                        }
+                    }
+                }
+                //Loop over spells to see if anything available
                 if (!buttonSet)
                 {
                     for (int i = 0; i < cs.queue.Length; i++)

--- a/Assets/Scripts/Players/PlaceTrap.cs
+++ b/Assets/Scripts/Players/PlaceTrap.cs
@@ -631,7 +631,7 @@ public class PlaceTrap : MonoBehaviour {
                 bool buttonSet = false;
                 for (int i = 0; i < queue.Count; i++)
                 {
-                    if (queue[i].activeInHierarchy && !buttonSet)
+                    if (queue[i].activeInHierarchy && !buttonSet && queue[i].GetComponent<Button>().interactable)
                     {
                         eventSystem.SetSelectedGameObject(queue[i]);
                         buttonSet = true;

--- a/Assets/Scripts/Spells/SpellBase.cs
+++ b/Assets/Scripts/Spells/SpellBase.cs
@@ -171,9 +171,6 @@ public class SpellBase : MonoBehaviour {
         float slowTimePassed = 0;
         while (slowTimePassed <= slowDuration)
         {
-
-            Debug.Log(slowTimePassed);
-
             slowTimePassed += Time.deltaTime;
             player.gameObject.GetComponent<PlayerOneMovement>().SetSpeed(slowSpeed);
 

--- a/Assets/Scripts/UI/ButtonSelect.cs
+++ b/Assets/Scripts/UI/ButtonSelect.cs
@@ -15,7 +15,7 @@ public class ButtonSelect : MonoBehaviour, ISelectHandler, IDeselectHandler// re
     private TextMeshProUGUI tooltip;
     private MoveControllerCursor cursorMove;
     private GameObject currentFirstSpell;
-    private GameObject currentFirstTrap;
+    private GameObject currentLastTrap;
 
     private AudioSource audioSource;
     private Vector3 buttonScale;
@@ -59,9 +59,9 @@ public class ButtonSelect : MonoBehaviour, ISelectHandler, IDeselectHandler// re
             if (Input.GetAxis("Horizontal_Menu") < 0 || IsSpellQueueNull())
             {
                 if(cs != null) cs.DestroyTarget();
-                if (currentFirstTrap != null && currentFirstTrap.gameObject == this.gameObject)
+                if (currentLastTrap != null && currentLastTrap.gameObject == this.gameObject && currentLastTrap.gameObject.GetComponent<Button>().interactable)
                 {
-                    currentFirstTrap = null;
+                    currentLastTrap = null;
                     controllerCursor.transform.localPosition = new Vector3(0, 130);
                     cursorMove.MovingTraps = true;
 
@@ -164,7 +164,7 @@ public class ButtonSelect : MonoBehaviour, ISelectHandler, IDeselectHandler// re
             {
                 if (pt.queue[t] != null && pt.queue[t].activeInHierarchy && pt.queue[t].GetComponent<Button>().interactable)
                 {
-                    currentFirstTrap = pt.queue[t];
+                    currentLastTrap = pt.queue[t];
                     return;
                 }
             }

--- a/Assets/Scripts/UI/CheckControllers.cs
+++ b/Assets/Scripts/UI/CheckControllers.cs
@@ -11,8 +11,7 @@ public class CheckControllers : MonoBehaviour {
     private Canvas canvas;
     private SetEventTriggerVars[] eventVars;
     private SetPointerClickEvents[] clickEvents;
-    private GameObject trapQueue;
-    private GameObject spellQueue;
+
     private Button[] trapButtons;
     private Button[] spellButtons;
 
@@ -20,12 +19,11 @@ public class CheckControllers : MonoBehaviour {
     {
         joysticks = Input.GetJoystickNames();
 
-        canvas = GameObject.Find("Canvas").GetComponent<Canvas>();
+        GameObject canv = GameObject.Find("Canvas");
+        if(canv != null) canvas = canv.GetComponent<Canvas>();
         GameObject tower = GameObject.Find("Tower");
-        eventVars = tower.GetComponentsInChildren<SetEventTriggerVars>();
-        clickEvents = tower.GetComponentsInChildren<SetPointerClickEvents>();
-        trapQueue = GameObject.Find("TrapQueue");
-        spellQueue = GameObject.Find("SpellQueue");
+        if(tower != null) eventVars = tower.GetComponentsInChildren<SetEventTriggerVars>();
+        if(tower != null) clickEvents = tower.GetComponentsInChildren<SetPointerClickEvents>();
 
         CheckConnected();
         Debug.Log("Player 1 controller: " + controllerOne);
@@ -58,25 +56,18 @@ public class CheckControllers : MonoBehaviour {
                         controllerTwo = true;
                         Cursor.visible = false;
                         Cursor.lockState = CursorLockMode.Locked;
-                        canvas.GetComponent<GraphicRaycaster>().enabled = false;
-                        foreach(SetEventTriggerVars v in eventVars)
-                        {
-                            v.enabled = false;
-                        }
-                        foreach (SetPointerClickEvents p in clickEvents)
-                        {
-                            p.enabled = false;
-                        }
-                        spellButtons = spellQueue.GetComponentsInChildren<Button>();
 
-                        foreach(Button sb in spellButtons)
+                        if(canvas != null && eventVars != null)
                         {
-                            sb.GetComponent<EventTrigger>().enabled = false;
-                        }
-                        trapButtons = trapQueue.GetComponentsInChildren<Button>();
-                        foreach(Button tb in trapButtons)
-                        {
-                            tb.GetComponent<EventTrigger>().enabled = false;
+                            canvas.GetComponent<GraphicRaycaster>().enabled = false;
+                            foreach (SetEventTriggerVars v in eventVars)
+                            {
+                                v.enabled = false;
+                            }
+                            foreach (SetPointerClickEvents p in clickEvents)
+                            {
+                                p.enabled = false;
+                            }
                         }
                     }
                 }
@@ -92,16 +83,18 @@ public class CheckControllers : MonoBehaviour {
                         controllerTwo = false;
                         Cursor.visible = true;
                         Cursor.lockState = CursorLockMode.None;
-                        canvas.GetComponent<GraphicRaycaster>().enabled = true;
-                        foreach (SetEventTriggerVars v in eventVars)
+                        if(canvas != null && eventVars != null)
                         {
-                            v.enabled = true;
+                            canvas.GetComponent<GraphicRaycaster>().enabled = true;
+                            foreach (SetEventTriggerVars v in eventVars)
+                            {
+                                v.enabled = true;
+                            }
+                            foreach (SetPointerClickEvents p in clickEvents)
+                            {
+                                p.enabled = true;
+                            }
                         }
-                        foreach (SetPointerClickEvents p in clickEvents)
-                        {
-                            p.enabled = true;
-                        }
-
                     }
                 }
             }

--- a/Assets/Scripts/UI/PauseMenu.cs
+++ b/Assets/Scripts/UI/PauseMenu.cs
@@ -20,7 +20,11 @@ public class PauseMenu : MonoBehaviour {
     private CastSpell cs;
     private PlayerOneMovement playerMov;
 
+    //When we pause/resume we need to set the trap/spell buttons uninteractable, then interactable again
+    //these bool arrays keep track of which ones are used/on cooldown so we don't set them interactable on resume
     private bool[] onCooldown;
+    private bool[] usedTraps;
+
     private bool controlsUp;
     private GameObject selectedButton;
     private void Start()
@@ -62,6 +66,8 @@ public class PauseMenu : MonoBehaviour {
 	
 	public void Resume(){
 		pauseMenuUI.SetActive(false);
+
+        //Set correct spell buttons interactable again
         for (int i = 0; i < cs.queue.Length; i++)
         {
             if (cs.queue[i] != null && !onCooldown[i])
@@ -69,9 +75,13 @@ public class PauseMenu : MonoBehaviour {
                 cs.queue[i].GetComponent<Button>().interactable = true;
             }
         }
+        //Set correct trap buttons interactable again
         for (int i = 0; i < pt.queue.Count; i++)
         {
-            if (pt.active) pt.queue[i].GetComponent<Button>().interactable = true;
+            if (pt.active && pt.queue[i] != null && !usedTraps[i])
+            {
+                pt.queue[i].GetComponent<Button>().interactable = true;
+            }
         }
         es.SetSelectedGameObject(selectedButton);
 
@@ -88,6 +98,9 @@ public class PauseMenu : MonoBehaviour {
 	public void Pause(){
         //Set buttons not interactable
         selectedButton = es.currentSelectedGameObject;
+        
+        //Keep track of which spells are on cooldown / uninteractable so we don't set them interactable when we resume.
+        //& set the button uninteractable
         onCooldown = new bool[cs.queue.Length];
         for (int i = 0; i < cs.queue.Length; i++)
         {
@@ -105,9 +118,21 @@ public class PauseMenu : MonoBehaviour {
                 }
             }
         }
+        //Keep track of which traps have been used && set them uninteractable
+        usedTraps = new bool[pt.queue.Count];
         for (int i = 0; i < pt.queue.Count; i++)
         {
-            pt.queue[i].GetComponent<Button>().interactable = false;
+            if(pt.queue[i].GetComponent<Button>().interactable)
+            {
+                usedTraps[i] = false;
+
+                pt.queue[i].GetComponent<Button>().interactable = false;
+            }
+            else
+            {
+                usedTraps[i] = true;
+            }
+            
         }
 
         //Bring up Pause menu


### PR DESCRIPTION
- Set selected button properly in event system - wasn't checking if button was interactable before setting the selected button, which is why you were sometimes able to place the same trap repeatedly
- Make sure not to re-enable all traps after pausing
- Polished selection of next button - will go one to the right within the same queue (i.e., if you placed a trap, you will get the next trap over; if there are no more traps to the right, it will go to the next trap backwards, and so on. We might need to talk about how we want it to work more in detail)