### PR TITLE
Lowered Cooldowns of Spell at the Last Face

### DIFF
--- a/Assets/Prefabs/Players and Cameras/Player 2.prefab
+++ b/Assets/Prefabs/Players and Cameras/Player 2.prefab
@@ -309,6 +309,7 @@ MonoBehaviour:
   trapPlacementGood: {fileID: 8300000, guid: 6f7b61c54b3d3904d9e08ffdca119496, type: 3}
   trapPlacementBad: {fileID: 8300000, guid: 146332e6c2633ee4bbced98f867e9780, type: 3}
   queueSize: 7
+  InputEnabled: 1
 --- !u!114 &114871698429783546
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -322,6 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   queueSize: 3
   verticalSpellSpawnHeight: 100
+  CooldownReductionPercentage: 0.75
   tower: {fileID: 0}
   spellButtons:
   - {fileID: 1113329559578948, guid: 9caafb2bc87b57a46a16da291b5e206d, type: 2}
@@ -349,6 +351,7 @@ MonoBehaviour:
   - {fileID: 1424637060701814, guid: e34ed2dd750177e4ba19c7100de1f5df, type: 2}
   - {fileID: 1424637060701814, guid: 5d4a7e903769c9245a97278745db2832, type: 2}
   placeEnabled: 0
+  InputEnabled: 1
 --- !u!136 &136189357046121884
 CapsuleCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Players and Cameras/Player 2.prefab
+++ b/Assets/Prefabs/Players and Cameras/Player 2.prefab
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   queueSize: 3
   verticalSpellSpawnHeight: 100
-  CooldownReductionPercentage: 0.75
+  CooldownReductionPercentage: 0.25
   tower: {fileID: 0}
   spellButtons:
   - {fileID: 1113329559578948, guid: 9caafb2bc87b57a46a16da291b5e206d, type: 2}

--- a/Assets/Scripts/Players/CastSpell.cs
+++ b/Assets/Scripts/Players/CastSpell.cs
@@ -9,6 +9,7 @@ public class CastSpell : MonoBehaviour
     [Header("Design Values -------------")]
     [SerializeField] private int queueSize;
     [SerializeField] private int verticalSpellSpawnHeight;
+    [SerializeField] private float CooldownReductionPercentage;
 
     //[SerializeField] [Tooltip("Must be in SAME ORDER and SAME AMOUNT of spell prefabs and spell buttons arrays.")]
     //private float[] spellCooldowns;
@@ -47,6 +48,7 @@ public class CastSpell : MonoBehaviour
     private GameObject spellTarget;
     private GameObject castedSpell;
     private float spellSpeed;
+    private bool atTop = false;
 
     //for spell movement and spawning
     private int ValidLocation;
@@ -125,6 +127,7 @@ public class CastSpell : MonoBehaviour
             eventSystem.SetSelectedGameObject(currentSelectedGameObject);
             //    SetSelectedButton();
         }
+        atTop = GetComponent<PlaceTrap>().LastFace();
     }
 
     void FixedUpdate()
@@ -271,7 +274,14 @@ public class CastSpell : MonoBehaviour
                     }
                     castedSpell.GetComponent<SpellBase>().SpellCast = true;
                 }
-                StartCoroutine(StartCooldown(spell.GetComponent<SpellBase>().CooldownTime, queue[queueIndex].transform.localPosition, queueIndex));
+                if (atTop == false)
+                {
+                    StartCoroutine(StartCooldown(spell.GetComponent<SpellBase>().CooldownTime, queue[queueIndex].transform.localPosition, queueIndex));
+                }
+                else
+                {
+                    StartCoroutine(StartCooldown((spell.GetComponent<SpellBase>().CooldownTime - (spell.GetComponent<SpellBase>().CooldownTime * CooldownReductionPercentage)), queue[queueIndex].transform.localPosition, queueIndex));
+                }
 
                 previouslySelectedIndex = queueIndex;
 

--- a/Assets/Scripts/Players/PlaceTrap.cs
+++ b/Assets/Scripts/Players/PlaceTrap.cs
@@ -63,6 +63,7 @@ public class PlaceTrap : MonoBehaviour {
     private InputManager inputManager;
 
     private int numTimesRotated = 0;
+    private bool atTop = false;
 
     private void Awake()
     {
@@ -659,4 +660,16 @@ public class PlaceTrap : MonoBehaviour {
             }
         }
     }
+
+    //Getter
+    public bool LastFace()
+    {
+        if (numTimesRotated == 4 * (tower.GetComponentInChildren<NumberOfFloors>().NumFloors - 1) - 1)
+        {
+            atTop = true;
+        }
+        return atTop;
+    }
 }
+
+


### PR DESCRIPTION
Spells at the last face have a cooldown reduction of 75%.

Works in both tower1 and tutorial scene.

Cooldown Reduction is serialized variable on Player 2. Has to be a decimal number.

Delete branch.