### PR TITLE
Bumper&tab fix

### DIFF
--- a/Assets/Scenes/Tower1.unity
+++ b/Assets/Scenes/Tower1.unity
@@ -234,7 +234,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.20629
+      value: -80.18245
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalRotation.x
@@ -1626,7 +1626,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4118745448429798, guid: 4177dabbb2b6dc24aa87ac8ef64cc13e, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 9.41088
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 4118745448429798, guid: 4177dabbb2b6dc24aa87ac8ef64cc13e, type: 2}
       propertyPath: m_LocalPosition.z
@@ -2458,7 +2458,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4743651345122740, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 9.41088
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 4743651345122740, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
       propertyPath: m_LocalPosition.z
@@ -2585,6 +2585,7 @@ GameObject:
   - component: {fileID: 1160000098}
   - component: {fileID: 1160000097}
   - component: {fileID: 1160000096}
+  - component: {fileID: 1160000099}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -2637,6 +2638,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1160000099
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1160000095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea4993bb3e9bd864680a55b074f9dec6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1165073088 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114956843716667498, guid: 295df6c694235764eac79c393ed826dc,
@@ -4077,7 +4089,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.20629
+      value: -80.18245
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalRotation.x

--- a/Assets/Scenes/Tutorial.unity
+++ b/Assets/Scenes/Tutorial.unity
@@ -208,7 +208,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.20629
+      value: -80.18245
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalRotation.x
@@ -2656,6 +2656,7 @@ GameObject:
   - component: {fileID: 1160000098}
   - component: {fileID: 1160000097}
   - component: {fileID: 1160000096}
+  - component: {fileID: 1160000099}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -2708,6 +2709,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1160000099
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1160000095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea4993bb3e9bd864680a55b074f9dec6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1163787054
 GameObject:
   m_ObjectHideFlags: 0
@@ -5125,7 +5137,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.20629
+      value: -80.18245
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalRotation.x

--- a/Assets/Scripts/Input&ChacterSelection/SetInputModule.cs
+++ b/Assets/Scripts/Input&ChacterSelection/SetInputModule.cs
@@ -1,0 +1,27 @@
+﻿using UnityEngine;
+using UnityEngine.EventSystems;
+
+//Sets the horizontal navigation component of the event system based on which controller is the top player
+public class SetInputModule : MonoBehaviour {
+    private InputManager inputManager;
+    private StandaloneInputModule inputModule;
+
+    private void Awake()
+    {
+        inputManager = GameObject.Find("InputManager").GetComponent<InputManager>();
+        inputModule = GetComponent<StandaloneInputModule>();
+    }
+
+    private void Start ()
+    {
+        if(inputManager.P1IsTop)
+        {
+            inputModule.horizontalAxis = "Bumpers_Joy_1";
+        }
+        else
+        {
+            inputModule.horizontalAxis = "Bumpers_Joy_2";
+        }
+	}
+
+}

--- a/Assets/Scripts/Input&ChacterSelection/SetInputModule.cs.meta
+++ b/Assets/Scripts/Input&ChacterSelection/SetInputModule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea4993bb3e9bd864680a55b074f9dec6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/GameOverMenu.cs
+++ b/Assets/Scripts/UI/GameOverMenu.cs
@@ -20,7 +20,7 @@ public class GameOverMenu : MonoBehaviour {
 
     private void Update()
     {
-        if (cc.GetControllerOneState() || cc.GetControllerTwoState() && es.currentSelectedGameObject == null)
+        if ((cc.GetControllerOneState() || cc.GetControllerTwoState()) && es.currentSelectedGameObject == null)
         {
             es.SetSelectedGameObject(menuButtons[0]);
         }

--- a/Assets/Scripts/UI/GameOverMenu.cs
+++ b/Assets/Scripts/UI/GameOverMenu.cs
@@ -12,7 +12,15 @@ public class GameOverMenu : MonoBehaviour {
     private void Start()
     {
         cc = GetComponent<CheckControllers>();
-        if(cc.GetControllerOneState())
+        if(cc.GetControllerOneState() || cc.GetControllerTwoState())
+        {
+            es.SetSelectedGameObject(menuButtons[0]);
+        }
+    }
+
+    private void Update()
+    {
+        if (cc.GetControllerOneState() || cc.GetControllerTwoState() && es.currentSelectedGameObject == null)
         {
             es.SetSelectedGameObject(menuButtons[0]);
         }

--- a/Assets/Scripts/UI/MainMenu.cs
+++ b/Assets/Scripts/UI/MainMenu.cs
@@ -41,7 +41,7 @@ public class MainMenu : MonoBehaviour {
 
     private void Update()
     {
-        if (checkControllers.GetControllerOneState() || checkControllers.GetControllerTwoState() && es.currentSelectedGameObject == null)
+        if ((checkControllers.GetControllerOneState() || checkControllers.GetControllerTwoState()) && es.currentSelectedGameObject == null)
         {
             es.SetSelectedGameObject(menuButtons[0].gameObject);
         }

--- a/Assets/Scripts/UI/MainMenu.cs
+++ b/Assets/Scripts/UI/MainMenu.cs
@@ -39,6 +39,14 @@ public class MainMenu : MonoBehaviour {
         }
 	}
 
+    private void Update()
+    {
+        if (checkControllers.GetControllerOneState() || checkControllers.GetControllerTwoState() && es.currentSelectedGameObject == null)
+        {
+            es.SetSelectedGameObject(menuButtons[0].gameObject);
+        }
+    }
+
     public void OnClickPlay()
     {
         CheckControllers cc = inputManager.GetComponent<CheckControllers>();

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -185,8 +185,8 @@ InputManager:
     m_Name: Bumpers_Joy_1
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: joystick 2 button 4
-    positiveButton: joystick 2 button 5
+    negativeButton: joystick 1 button 4
+    positiveButton: joystick 1 button 5
     altNegativeButton: 
     altPositiveButton: 
     gravity: 10


### PR DESCRIPTION
- Bumpers to navigate traps/spells should now work with both controllers as top player (previously would only work with the second controller)
- Clicking on the main menu and game over screens OR alt tabbing out of build on these screens would previously cause controller to stop working / selecting the buttons - fixed it