### PR TITLE
New speed

### DIFF
--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -240,7 +240,7 @@ public class PlayerOneMovement : MonoBehaviour {
                 break;
         }
 
-        if (crouching == true && spedUp == false)
+        if (crouching == true)
         {
             CrouchPenalty = crouchSlow;
             col.height = 2.25f;

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -125,19 +125,17 @@ public class PlayerOneMovement : MonoBehaviour {
             }
             if (inputManager.GetButtonUp(InputCommand.BottomPlayerCrouch) || (!inputManager.GetButton(InputCommand.BottomPlayerCrouch) && cantStandUp == false))
             {
-                if (spedUp == false)
+                if (cantStandUp == true)
                 {
-                    if (cantStandUp == true)
-                    {
-                        crouching = true;
-                        CrouchPenalty = crouchSlow;
-                    }
-                    if (cantStandUp == false)
-                    {
-                        crouching = false;
-                        CrouchPenalty = 1;
-                    }
+                    crouching = true;
+                    CrouchPenalty = crouchSlow;
                 }
+                if (cantStandUp == false)
+                {
+                    crouching = false;
+                    CrouchPenalty = 1;
+                }
+                
             }
             // Animation parameters update
             animator.SetBool("Jumping", jumping);
@@ -382,6 +380,7 @@ public class PlayerOneMovement : MonoBehaviour {
         yield return new WaitForSeconds(timePerPickup);
         pickupImages[0].sprite = pickupEmpty;
 
+        spedUp = false;
         SuperSpeed = 1;
         gameObject.GetComponent<PlayerOneStats>().pickupCount = 0;
     }

--- a/Assets/Scripts/Spells/BallandChain.cs
+++ b/Assets/Scripts/Spells/BallandChain.cs
@@ -56,7 +56,6 @@ public class BallandChain : MonoBehaviour {
             if (hit)
             {
                 spellBase.Slow(player, slowRun, reduceJump, spellDuration);
-                player.GetComponent<PlayerOneMovement>().IsSlowed(true);
                 StartCoroutine(Wait(this.gameObject));
             }
         }
@@ -104,7 +103,6 @@ public class BallandChain : MonoBehaviour {
     private IEnumerator Wait(GameObject obj)
     {
         yield return new WaitForSeconds(spellDuration);
-        player.GetComponent<PlayerOneMovement>().IsSlowed(false);
         yield return new WaitForSeconds(0.1f);
         Destroy(obj);
     }
@@ -117,10 +115,6 @@ public class BallandChain : MonoBehaviour {
 
     private IEnumerator DestroyObj()
     {
-        if (player != null)
-        {
-            player.GetComponent<PlayerOneMovement>().IsSlowed(true);
-        }
         yield return new WaitForSeconds(0.1f);
         Destroy(this.gameObject);
     }

--- a/Assets/Scripts/Spells/SpellBase.cs
+++ b/Assets/Scripts/Spells/SpellBase.cs
@@ -116,8 +116,6 @@ public class SpellBase : MonoBehaviour {
 
     private IEnumerator WaitStun(GameObject player, float stunDuration, Material mat, Renderer[] child = null, Animator anim = null)
     {
-        float tempSpeed = player.gameObject.GetComponent<PlayerOneMovement>().GetSpeed();
-        player.gameObject.GetComponent<PlayerOneMovement>().SetSpeed(0);
         player.gameObject.GetComponent<PlayerOneMovement>().SetMove(false);
         player.gameObject.GetComponent<Rigidbody>().velocity = new Vector3(0, player.gameObject.GetComponent<Rigidbody>().velocity.y, 0);
         if (mat != null)
@@ -135,7 +133,6 @@ public class SpellBase : MonoBehaviour {
         while (stunTimePassed <= stunDuration)
         {            
             stunTimePassed += Time.deltaTime;
-            player.gameObject.GetComponent<PlayerOneMovement>().SetSpeed(0);
 
             player.gameObject.GetComponent<PlayerOneMovement>().SetMove(false);
 
@@ -144,7 +141,6 @@ public class SpellBase : MonoBehaviour {
 
         //  yield return new WaitForSeconds(stunDuration);
         player.gameObject.GetComponent<PlayerOneMovement>().SetMove(true);
-        player.GetComponent<PlayerOneMovement>().SetSpeed(tempSpeed);
         if (anim != null)
         {
             anim.enabled = true;
@@ -164,26 +160,28 @@ public class SpellBase : MonoBehaviour {
 
     private IEnumerator WaitSlow(GameObject player, float slowPercent, float jumpReductionPercent, float slowDuration)
     {
-        float tempSpeed = player.gameObject.GetComponent<PlayerOneMovement>().GetSpeed();
         player.gameObject.GetComponent<PlayerOneMovement>().SetJumpHeight(player.gameObject.GetComponent<PlayerOneMovement>().GetJumpHeight() * jumpReductionPercent);
-        float slowSpeed = player.gameObject.GetComponent<PlayerOneMovement>().GetSpeed() * slowPercent;
-        player.gameObject.GetComponent<PlayerOneMovement>().SetSpeed(slowSpeed);
-        player.gameObject.GetComponent<PlayerOneMovement>().IsSlowed(true);
+        float GetPenalty = player.gameObject.GetComponent<PlayerOneMovement>().GetSlowPenalty();
+        if (slowPercent <= GetPenalty)
+        {
+            player.gameObject.GetComponent<PlayerOneMovement>().SetSlowPenalty(slowPercent);
+        }
 
         float slowTimePassed = 0;
         while (slowTimePassed <= slowDuration)
         {
             slowTimePassed += Time.deltaTime;
-            player.gameObject.GetComponent<PlayerOneMovement>().SetSpeed(slowSpeed);
-
-            player.gameObject.GetComponent<PlayerOneMovement>().IsSlowed(true);
+            GetPenalty = player.gameObject.GetComponent<PlayerOneMovement>().GetSlowPenalty();
+            if (slowPercent <= GetPenalty)
+            {
+                player.gameObject.GetComponent<PlayerOneMovement>().SetSlowPenalty(slowPercent);
+            }
 
             yield return null;
         }
 
         player.GetComponent<PlayerOneMovement>().SetJumpHeight(player.GetComponent<PlayerOneMovement>().GetConstantJumpHeight());
-        player.GetComponent<PlayerOneMovement>().SetSpeed(tempSpeed);
-        player.gameObject.GetComponent<PlayerOneMovement>().IsSlowed(false);
+        player.GetComponent<PlayerOneMovement>().SetSlowPenalty(1);
     }
 
     public void RestartFace(GameObject obj)

--- a/Assets/Scripts/Traps/Sap.cs
+++ b/Assets/Scripts/Traps/Sap.cs
@@ -33,7 +33,6 @@ public class Sap : MonoBehaviour {
     {
         if(player != null)
         {
-            
             // if colliding, give an amount of slow
             if (hit && !player.GetComponent<PlayerOneMovement>().GetSpedUp())
             {
@@ -48,7 +47,7 @@ public class Sap : MonoBehaviour {
             else if (slowTriggered)
             {
                 player.GetComponent<PlayerOneMovement>().SetJumpHeight(player.GetComponent<PlayerOneMovement>().GetConstantJumpHeight());
-                player.GetComponent<PlayerOneMovement>().SetSpeed(player.GetComponent<PlayerOneMovement>().GetConstantSpeed());
+                player.GetComponent<PlayerOneMovement>().SetSlowPenalty(1);
                 slowTriggered = false;
             }
             if(slowTimer == 1 && anim != null)
@@ -56,7 +55,6 @@ public class Sap : MonoBehaviour {
                 //Animation ends 1 frame earlier than slow so that the next instance of sap touched will do the animation properly
                 //If this ended at the same time as the slow (= 0) then the previous instance of sap touched will call this function over and over again.
                 anim.SetBool("Slowed", hit);
-                player.gameObject.GetComponent<PlayerOneMovement>().IsSlowed(false);
 
             }
             // tick timer down if there is any
@@ -74,7 +72,6 @@ public class Sap : MonoBehaviour {
         {
             hit = true;
             player = other.gameObject;
-            player.gameObject.GetComponent<PlayerOneMovement>().IsSlowed(true);
             //Player animation goes to idle properly in sap.
             if (player.GetComponent<PlayerOneMovement>().GetInputAxis() != 0)
             {

--- a/Assets/Scripts/Traps/TrapBase.cs
+++ b/Assets/Scripts/Traps/TrapBase.cs
@@ -136,13 +136,10 @@ public class TrapBase : MonoBehaviour {
 
     private IEnumerator Wait(GameObject obj, float stunDuration, GameObject trap = null)
     {
-        float tempSpeed = obj.gameObject.GetComponent<PlayerOneMovement>().GetSpeed();
-        obj.gameObject.GetComponent<PlayerOneMovement>().SetSpeed(0);
         obj.gameObject.GetComponent<PlayerOneMovement>().SetMove(false);
         yield return new WaitForSeconds(stunDuration);
 
         obj.gameObject.GetComponent<PlayerOneMovement>().SetMove(true);
-        obj.GetComponent<PlayerOneMovement>().SetSpeed(tempSpeed);
 
         once = false;
         if (trap != null)
@@ -156,7 +153,11 @@ public class TrapBase : MonoBehaviour {
     public void Slow(GameObject obj, float slowPercent, float jumpReductionPercent)
     {
         obj.gameObject.GetComponent<PlayerOneMovement>().SetJumpHeight(obj.gameObject.GetComponent<PlayerOneMovement>().GetJumpHeight() * jumpReductionPercent);
-        obj.gameObject.GetComponent<PlayerOneMovement>().SetSpeed(obj.gameObject.GetComponent<PlayerOneMovement>().GetSpeed() * slowPercent);
+        float GetPenalty = obj.gameObject.GetComponent<PlayerOneMovement>().GetSlowPenalty();
+        if (slowPercent <= GetPenalty)
+        {
+            obj.gameObject.GetComponent<PlayerOneMovement>().SetSlowPenalty(slowPercent);
+        }
     }
 
     // apply knockback to inputted


### PR DESCRIPTION
Speed is now a big equation.
speed = (moveSpeed * SlowPenalty1 * StunPenalty * CrouchPenalty) * SpeedUpBonus
Each penalty or bonus is default 1 and changed to what is needed when player is hit by them.
Can add multiple slow penalty tiers if wanted. Strongest slow takes priority of other slows currently.

Slow and Stuns should not cause you to not be able to move.

Can Crouch and when sped up now and crouch speed penalty is applied to slows and speed up now.

Speed up can be penalized from slow spell.

Delete Branch.