### PR TITLE
Trap and Spell Rarity

### DIFF
--- a/Assets/Prefabs/Players and Cameras/Player 2.prefab
+++ b/Assets/Prefabs/Players and Cameras/Player 2.prefab
@@ -290,16 +290,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gridSize: 2
+  CommonRarityChance: 45
+  UncommonRarityChance: 35
+  RareRarityChance: 20
   tower: {fileID: 0}
-  trapButtons:
-  - {fileID: 1148860999998904, guid: ad3241910d1b2f54db2ac80af833dd05, type: 2}
+  CommonTrapButtons:
   - {fileID: 1110785462397992, guid: beb48e7d73b8a5949836542f424745f8, type: 2}
+  UncommonTrapButtons:
   - {fileID: 1881833347296892, guid: abd8a9fa5d7d7f24096cab103761e9a2, type: 2}
+  - {fileID: 1148860999998904, guid: ad3241910d1b2f54db2ac80af833dd05, type: 2}
+  RareTrapButtons:
   - {fileID: 1342018372598374, guid: 208c22d5edce409439fa7b3eb12a8ab6, type: 2}
-  trapPrefabs:
-  - {fileID: 114374902745233234, guid: 978902421daf7ca4eb1ed6dc15ac1645, type: 2}
+  CommonTrapPrefabs:
   - {fileID: 114603356562152718, guid: 14716dac1aa2c7a488003f7bba1968d3, type: 2}
+  UncommonTrapPrefabs:
   - {fileID: 114426541480001402, guid: 7b86cd6111e958843812033b42c97d80, type: 2}
+  - {fileID: 114374902745233234, guid: 978902421daf7ca4eb1ed6dc15ac1645, type: 2}
+  RareTrapPrefabs:
   - {fileID: 114173747208991380, guid: b34de131824cbe447931d0a2d1e0696b, type: 2}
   trapQueue: {fileID: 0}
   controllerCursor: {fileID: 0}
@@ -324,21 +331,28 @@ MonoBehaviour:
   queueSize: 3
   verticalSpellSpawnHeight: 100
   CooldownReductionPercentage: 0.25
+  CommonRarityChance: 50
+  UncommonRarityChance: 35
+  RareRarityChance: 15
   tower: {fileID: 0}
-  spellButtons:
+  CommonSpellButtons:
   - {fileID: 1113329559578948, guid: 9caafb2bc87b57a46a16da291b5e206d, type: 2}
-  - {fileID: 1613936015125488, guid: 4a067145d92a94685b6e22ef6edc3f4b, type: 2}
   - {fileID: 1113329559578948, guid: 4fcae1fa39201f24cb3eb5a005187de5, type: 2}
-  - {fileID: 1113329559578948, guid: 6a89e440e2925b14c9bb31d09e4d2c2f, type: 2}
+  UncommonSpellButtons:
   - {fileID: 1113329559578948, guid: d5688845a27f247f8856e27dbb5cf2e8, type: 2}
   - {fileID: 1113329559578948, guid: a515d837040864ce486d259b379aca39, type: 2}
-  spellPrefabs:
+  RareSpellButtons:
+  - {fileID: 1113329559578948, guid: 6a89e440e2925b14c9bb31d09e4d2c2f, type: 2}
+  - {fileID: 1613936015125488, guid: 4a067145d92a94685b6e22ef6edc3f4b, type: 2}
+  CommonSpellPrefabs:
   - {fileID: 114692542700711350, guid: 1be1b6caab1fd324698fced99786f928, type: 2}
-  - {fileID: 114692542700711350, guid: 7a8dfb4bd9fe5404c9de268e4b6a114f, type: 2}
   - {fileID: 114666726713938728, guid: a1877a9fcd9b1044b903f7eb78d4662f, type: 2}
-  - {fileID: 114692542700711350, guid: 4ccad5a5f67c07f48b38c70dbdfb34cb, type: 2}
+  UncommonSpellPrefabs:
   - {fileID: 114692542700711350, guid: 80156f25595d343399a190b204285c71, type: 2}
   - {fileID: 114666726713938728, guid: b22aaa237e58e459b8de7de4cc8a9106, type: 2}
+  RareSpellPrefabs:
+  - {fileID: 114692542700711350, guid: 4ccad5a5f67c07f48b38c70dbdfb34cb, type: 2}
+  - {fileID: 114692542700711350, guid: 7a8dfb4bd9fe5404c9de268e4b6a114f, type: 2}
   spellQueue: {fileID: 0}
   controllerCursor: {fileID: 0}
   eventSystem: {fileID: 0}

--- a/Assets/Scenes/Tower1.unity
+++ b/Assets/Scenes/Tower1.unity
@@ -1816,6 +1816,16 @@ Prefab:
       propertyPath: RareTrapPrefabs.Array.size
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: RareSpellButtons.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: RareSpellPrefabs.Array.size
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
         type: 2}
       propertyPath: CommonTrapButtons.Array.size
@@ -1826,6 +1836,16 @@ Prefab:
       propertyPath: CommonTrapPrefabs.Array.size
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: CommonSpellButtons.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: CommonSpellPrefabs.Array.size
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
         type: 2}
       propertyPath: UncommonTrapButtons.Array.size
@@ -1834,6 +1854,16 @@ Prefab:
     - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
         type: 2}
       propertyPath: UncommonTrapPrefabs.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonSpellButtons.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonSpellPrefabs.Array.size
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4994873547233482, guid: 7c17f18a57460024ba6258242e429410, type: 2}
@@ -2085,6 +2115,78 @@ Prefab:
       propertyPath: RareTrapButtons.Array.data[0]
       value: 
       objectReference: {fileID: 1342018372598374, guid: 208c22d5edce409439fa7b3eb12a8ab6,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: CommonSpellButtons.Array.data[0]
+      value: 
+      objectReference: {fileID: 1113329559578948, guid: 9caafb2bc87b57a46a16da291b5e206d,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: CommonSpellButtons.Array.data[1]
+      value: 
+      objectReference: {fileID: 1113329559578948, guid: 4fcae1fa39201f24cb3eb5a005187de5,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: RareSpellButtons.Array.data[1]
+      value: 
+      objectReference: {fileID: 1613936015125488, guid: 4a067145d92a94685b6e22ef6edc3f4b,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: RareSpellButtons.Array.data[0]
+      value: 
+      objectReference: {fileID: 1113329559578948, guid: 6a89e440e2925b14c9bb31d09e4d2c2f,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonSpellButtons.Array.data[0]
+      value: 
+      objectReference: {fileID: 1113329559578948, guid: d5688845a27f247f8856e27dbb5cf2e8,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonSpellButtons.Array.data[1]
+      value: 
+      objectReference: {fileID: 1113329559578948, guid: a515d837040864ce486d259b379aca39,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: RareSpellPrefabs.Array.data[1]
+      value: 
+      objectReference: {fileID: 114692542700711350, guid: 7a8dfb4bd9fe5404c9de268e4b6a114f,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: RareSpellPrefabs.Array.data[0]
+      value: 
+      objectReference: {fileID: 114692542700711350, guid: 4ccad5a5f67c07f48b38c70dbdfb34cb,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: CommonSpellPrefabs.Array.data[1]
+      value: 
+      objectReference: {fileID: 114666726713938728, guid: a1877a9fcd9b1044b903f7eb78d4662f,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: CommonSpellPrefabs.Array.data[0]
+      value: 
+      objectReference: {fileID: 114692542700711350, guid: 1be1b6caab1fd324698fced99786f928,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonSpellPrefabs.Array.data[0]
+      value: 
+      objectReference: {fileID: 114692542700711350, guid: 80156f25595d343399a190b204285c71,
+        type: 2}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonSpellPrefabs.Array.data[1]
+      value: 
+      objectReference: {fileID: 114666726713938728, guid: b22aaa237e58e459b8de7de4cc8a9106,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c17f18a57460024ba6258242e429410, type: 2}

--- a/Assets/Scenes/Tower1.unity
+++ b/Assets/Scenes/Tower1.unity
@@ -230,11 +230,11 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 29.999998
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.20629
+      value: -80.22221
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalRotation.x
@@ -1549,7 +1549,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4118745448429798, guid: 4177dabbb2b6dc24aa87ac8ef64cc13e, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 11.194498
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 4118745448429798, guid: 4177dabbb2b6dc24aa87ac8ef64cc13e, type: 2}
       propertyPath: m_LocalPosition.z
@@ -1806,6 +1806,36 @@ Prefab:
       propertyPath: spellPrefabs.Array.size
       value: 6
       objectReference: {fileID: 0}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: RareTrapButtons.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: RareTrapPrefabs.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: CommonTrapButtons.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: CommonTrapPrefabs.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonTrapButtons.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonTrapPrefabs.Array.size
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 4994873547233482, guid: 7c17f18a57460024ba6258242e429410, type: 2}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -2007,6 +2037,54 @@ Prefab:
       propertyPath: targeting.Array.data[2]
       value: 
       objectReference: {fileID: 1424637060701814, guid: 5d4a7e903769c9245a97278745db2832,
+        type: 2}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: CommonTrapPrefabs.Array.data[0]
+      value: 
+      objectReference: {fileID: 114603356562152718, guid: 14716dac1aa2c7a488003f7bba1968d3,
+        type: 2}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonTrapPrefabs.Array.data[0]
+      value: 
+      objectReference: {fileID: 114426541480001402, guid: 7b86cd6111e958843812033b42c97d80,
+        type: 2}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonTrapPrefabs.Array.data[1]
+      value: 
+      objectReference: {fileID: 114374902745233234, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: RareTrapPrefabs.Array.data[0]
+      value: 
+      objectReference: {fileID: 114173747208991380, guid: b34de131824cbe447931d0a2d1e0696b,
+        type: 2}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonTrapButtons.Array.data[1]
+      value: 
+      objectReference: {fileID: 1148860999998904, guid: ad3241910d1b2f54db2ac80af833dd05,
+        type: 2}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: UncommonTrapButtons.Array.data[0]
+      value: 
+      objectReference: {fileID: 1881833347296892, guid: abd8a9fa5d7d7f24096cab103761e9a2,
+        type: 2}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: CommonTrapButtons.Array.data[0]
+      value: 
+      objectReference: {fileID: 1110785462397992, guid: beb48e7d73b8a5949836542f424745f8,
+        type: 2}
+    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: RareTrapButtons.Array.data[0]
+      value: 
+      objectReference: {fileID: 1342018372598374, guid: 208c22d5edce409439fa7b3eb12a8ab6,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c17f18a57460024ba6258242e429410, type: 2}
@@ -2335,7 +2413,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4743651345122740, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 11.194498
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 4743651345122740, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
       propertyPath: m_LocalPosition.z
@@ -3556,11 +3634,11 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 29.999998
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.20629
+      value: -80.22221
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalRotation.x

--- a/Assets/Scenes/Tower1.unity
+++ b/Assets/Scenes/Tower1.unity
@@ -230,11 +230,11 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 30
+      value: 29.999998
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.22221
+      value: -80.20629
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalRotation.x
@@ -1549,7 +1549,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4118745448429798, guid: 4177dabbb2b6dc24aa87ac8ef64cc13e, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 11
+      value: 11.194498
       objectReference: {fileID: 0}
     - target: {fileID: 4118745448429798, guid: 4177dabbb2b6dc24aa87ac8ef64cc13e, type: 2}
       propertyPath: m_LocalPosition.z
@@ -1786,86 +1786,6 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: targeting.Array.size
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: trapButtons.Array.size
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: spellButtons.Array.size
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: spellPrefabs.Array.size
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: RareTrapButtons.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: RareTrapPrefabs.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: RareSpellButtons.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: RareSpellPrefabs.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: CommonTrapButtons.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: CommonTrapPrefabs.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: CommonSpellButtons.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: CommonSpellPrefabs.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonTrapButtons.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonTrapPrefabs.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonSpellButtons.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonSpellPrefabs.Array.size
-      value: 2
-      objectReference: {fileID: 0}
     - target: {fileID: 4994873547233482, guid: 7c17f18a57460024ba6258242e429410, type: 2}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -1898,6 +1818,16 @@ Prefab:
       propertyPath: m_RootOrder
       value: 10
       objectReference: {fileID: 0}
+    - target: {fileID: 114169544570823518, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: gameManager
+      value: 
+      objectReference: {fileID: 1016487807}
+    - target: {fileID: 114169544570823518, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: controllerCursor
+      value: 
+      objectReference: {fileID: 1513495130}
     - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
         type: 2}
       propertyPath: tower
@@ -1928,21 +1858,16 @@ Prefab:
       propertyPath: cam
       value: 
       objectReference: {fileID: 412805862}
-    - target: {fileID: 114169544570823518, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: gameManager
-      value: 
-      objectReference: {fileID: 1016487807}
-    - target: {fileID: 114169544570823518, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: controllerCursor
-      value: 
-      objectReference: {fileID: 1513495130}
     - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
         type: 2}
       propertyPath: tower
       value: 
       objectReference: {fileID: 1219273410}
+    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
+        type: 2}
+      propertyPath: spellQueue
+      value: 
+      objectReference: {fileID: 10065831}
     - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
         type: 2}
       propertyPath: controllerCursor
@@ -1973,221 +1898,6 @@ Prefab:
       propertyPath: playerOne
       value: 
       objectReference: {fileID: 1338709831}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: spellQueue
-      value: 
-      objectReference: {fileID: 10065831}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: targeting.Array.data[0]
-      value: 
-      objectReference: {fileID: 1046908235356196, guid: 0ded149890f182d4685b20ceb6c49d1b,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: targeting.Array.data[1]
-      value: 
-      objectReference: {fileID: 1424637060701814, guid: e34ed2dd750177e4ba19c7100de1f5df,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: spellPrefabs.Array.data[2]
-      value: 
-      objectReference: {fileID: 114666726713938728, guid: a1877a9fcd9b1044b903f7eb78d4662f,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: spellButtons.Array.data[5]
-      value: 
-      objectReference: {fileID: 1113329559578948, guid: a515d837040864ce486d259b379aca39,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: spellPrefabs.Array.data[5]
-      value: 
-      objectReference: {fileID: 114666726713938728, guid: b22aaa237e58e459b8de7de4cc8a9106,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: spellButtons.Array.data[0]
-      value: 
-      objectReference: {fileID: 1113329559578948, guid: 9caafb2bc87b57a46a16da291b5e206d,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: spellButtons.Array.data[1]
-      value: 
-      objectReference: {fileID: 1613936015125488, guid: 4a067145d92a94685b6e22ef6edc3f4b,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: spellButtons.Array.data[2]
-      value: 
-      objectReference: {fileID: 1113329559578948, guid: 4fcae1fa39201f24cb3eb5a005187de5,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: spellButtons.Array.data[3]
-      value: 
-      objectReference: {fileID: 1113329559578948, guid: 6a89e440e2925b14c9bb31d09e4d2c2f,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: spellButtons.Array.data[4]
-      value: 
-      objectReference: {fileID: 1113329559578948, guid: d5688845a27f247f8856e27dbb5cf2e8,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: trapButtons.Array.data[0]
-      value: 
-      objectReference: {fileID: 1148860999998904, guid: ad3241910d1b2f54db2ac80af833dd05,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: trapButtons.Array.data[1]
-      value: 
-      objectReference: {fileID: 1110785462397992, guid: beb48e7d73b8a5949836542f424745f8,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: trapButtons.Array.data[2]
-      value: 
-      objectReference: {fileID: 1881833347296892, guid: abd8a9fa5d7d7f24096cab103761e9a2,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: trapButtons.Array.data[3]
-      value: 
-      objectReference: {fileID: 1342018372598374, guid: 208c22d5edce409439fa7b3eb12a8ab6,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: targeting.Array.data[2]
-      value: 
-      objectReference: {fileID: 1424637060701814, guid: 5d4a7e903769c9245a97278745db2832,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: CommonTrapPrefabs.Array.data[0]
-      value: 
-      objectReference: {fileID: 114603356562152718, guid: 14716dac1aa2c7a488003f7bba1968d3,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonTrapPrefabs.Array.data[0]
-      value: 
-      objectReference: {fileID: 114426541480001402, guid: 7b86cd6111e958843812033b42c97d80,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonTrapPrefabs.Array.data[1]
-      value: 
-      objectReference: {fileID: 114374902745233234, guid: 978902421daf7ca4eb1ed6dc15ac1645,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: RareTrapPrefabs.Array.data[0]
-      value: 
-      objectReference: {fileID: 114173747208991380, guid: b34de131824cbe447931d0a2d1e0696b,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonTrapButtons.Array.data[1]
-      value: 
-      objectReference: {fileID: 1148860999998904, guid: ad3241910d1b2f54db2ac80af833dd05,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonTrapButtons.Array.data[0]
-      value: 
-      objectReference: {fileID: 1881833347296892, guid: abd8a9fa5d7d7f24096cab103761e9a2,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: CommonTrapButtons.Array.data[0]
-      value: 
-      objectReference: {fileID: 1110785462397992, guid: beb48e7d73b8a5949836542f424745f8,
-        type: 2}
-    - target: {fileID: 114220156261559540, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: RareTrapButtons.Array.data[0]
-      value: 
-      objectReference: {fileID: 1342018372598374, guid: 208c22d5edce409439fa7b3eb12a8ab6,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: CommonSpellButtons.Array.data[0]
-      value: 
-      objectReference: {fileID: 1113329559578948, guid: 9caafb2bc87b57a46a16da291b5e206d,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: CommonSpellButtons.Array.data[1]
-      value: 
-      objectReference: {fileID: 1113329559578948, guid: 4fcae1fa39201f24cb3eb5a005187de5,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: RareSpellButtons.Array.data[1]
-      value: 
-      objectReference: {fileID: 1613936015125488, guid: 4a067145d92a94685b6e22ef6edc3f4b,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: RareSpellButtons.Array.data[0]
-      value: 
-      objectReference: {fileID: 1113329559578948, guid: 6a89e440e2925b14c9bb31d09e4d2c2f,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonSpellButtons.Array.data[0]
-      value: 
-      objectReference: {fileID: 1113329559578948, guid: d5688845a27f247f8856e27dbb5cf2e8,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonSpellButtons.Array.data[1]
-      value: 
-      objectReference: {fileID: 1113329559578948, guid: a515d837040864ce486d259b379aca39,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: RareSpellPrefabs.Array.data[1]
-      value: 
-      objectReference: {fileID: 114692542700711350, guid: 7a8dfb4bd9fe5404c9de268e4b6a114f,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: RareSpellPrefabs.Array.data[0]
-      value: 
-      objectReference: {fileID: 114692542700711350, guid: 4ccad5a5f67c07f48b38c70dbdfb34cb,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: CommonSpellPrefabs.Array.data[1]
-      value: 
-      objectReference: {fileID: 114666726713938728, guid: a1877a9fcd9b1044b903f7eb78d4662f,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: CommonSpellPrefabs.Array.data[0]
-      value: 
-      objectReference: {fileID: 114692542700711350, guid: 1be1b6caab1fd324698fced99786f928,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonSpellPrefabs.Array.data[0]
-      value: 
-      objectReference: {fileID: 114692542700711350, guid: 80156f25595d343399a190b204285c71,
-        type: 2}
-    - target: {fileID: 114871698429783546, guid: 7c17f18a57460024ba6258242e429410,
-        type: 2}
-      propertyPath: UncommonSpellPrefabs.Array.data[1]
-      value: 
-      objectReference: {fileID: 114666726713938728, guid: b22aaa237e58e459b8de7de4cc8a9106,
-        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c17f18a57460024ba6258242e429410, type: 2}
   m_IsPrefabAsset: 0
@@ -2515,7 +2225,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4743651345122740, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 11
+      value: 11.194498
       objectReference: {fileID: 0}
     - target: {fileID: 4743651345122740, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
       propertyPath: m_LocalPosition.z
@@ -3736,11 +3446,11 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 30
+      value: 29.999998
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.22221
+      value: -80.20629
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalRotation.x

--- a/Assets/Scripts/Players/CastSpell.cs
+++ b/Assets/Scripts/Players/CastSpell.cs
@@ -11,6 +11,11 @@ public class CastSpell : MonoBehaviour
     [SerializeField] private int verticalSpellSpawnHeight;
     [SerializeField] private float CooldownReductionPercentage;
 
+    [Header("Percentage is X/100 currently.")]
+    [SerializeField] private int CommonRarityChance = 50;
+    [SerializeField] private int UncommonRarityChance = 35;
+    [SerializeField] private int RareRarityChance = 15;
+
     //[SerializeField] [Tooltip("Must be in SAME ORDER and SAME AMOUNT of spell prefabs and spell buttons arrays.")]
     //private float[] spellCooldowns;
 
@@ -18,8 +23,17 @@ public class CastSpell : MonoBehaviour
     [Header("Programmers - GameObjects/Scripts -----")]
     [SerializeField] private GameObject tower;
 
-    [SerializeField] private GameObject[] spellButtons;
-    [SerializeField] private SpellBase[] spellPrefabs;
+    //[SerializeField] private GameObject[] spellButtons;
+    //[SerializeField] private SpellBase[] spellPrefabs;
+
+    [SerializeField] private GameObject[] CommonSpellButtons;
+    [SerializeField] private GameObject[] UncommonSpellButtons;
+    [SerializeField] private GameObject[] RareSpellButtons;
+
+    [SerializeField] private SpellBase[] CommonSpellPrefabs;
+    [SerializeField] private SpellBase[] UncommonSpellPrefabs;
+    [SerializeField] private SpellBase[] RareSpellPrefabs;
+
     [SerializeField] private GameObject spellQueue;
 
     [SerializeField] private Image controllerCursor;
@@ -464,9 +478,33 @@ public class CastSpell : MonoBehaviour
         }
     }
 
-    private void OnClickSpell(int spellNum)
+    private void OnClickSpellCommon(int spellNum)
     {
-        spell = spellPrefabs[spellNum];
+        spell = CommonSpellPrefabs[spellNum];
+
+        StartCoroutine(EnableInput());
+
+        DestroyTarget();
+        GetComponent<PlaceTrap>().DestroyGhost();
+        SetTarget();
+        spellSpeed = spell.GetComponent<SpellBase>().GetSpeed();
+    }
+
+    private void OnClickSpellUncommon(int spellNum)
+    {
+        spell = UncommonSpellPrefabs[spellNum];
+
+        StartCoroutine(EnableInput());
+
+        DestroyTarget();
+        GetComponent<PlaceTrap>().DestroyGhost();
+        SetTarget();
+        spellSpeed = spell.GetComponent<SpellBase>().GetSpeed();
+    }
+
+    private void OnClickSpellRare(int spellNum)
+    {
+        spell = RareSpellPrefabs[spellNum];
 
         StartCoroutine(EnableInput());
 
@@ -485,16 +523,49 @@ public class CastSpell : MonoBehaviour
     private void GenerateNewSpell(Vector3 position, int index)
     {
         //Instantiate Spell Button
-        int random = Random.Range(0, spellButtons.Length);
-        GameObject newSpell = Instantiate(spellButtons[random], position, Quaternion.identity) as GameObject;
-        newSpell.transform.SetParent(spellQueue.transform, false);
+        int randomIndex;
+        GameObject newSpell;
+        int SpellChance = Random.Range(1, 100);
 
-        //Add Click Listener
-        newSpell.GetComponent<Button>().onClick.AddListener(() => OnClickSpell(random));
-        newSpell.GetComponent<ButtonIndex>().ButtonIndexing(index);
-        newSpell.GetComponent<Button>().onClick.AddListener(() => GetIndex(newSpell));
+        if (SpellChance <= CommonRarityChance)
+        {
+            randomIndex = Random.Range(0, CommonSpellButtons.Length);
+            newSpell = Instantiate(CommonSpellButtons[randomIndex], position, Quaternion.identity) as GameObject;
+            newSpell.transform.SetParent(spellQueue.transform, false);
 
-        queue[index] = newSpell;
+            //Add Click Listener
+            newSpell.GetComponent<Button>().onClick.AddListener(() => OnClickSpellCommon(randomIndex));
+            newSpell.GetComponent<ButtonIndex>().ButtonIndexing(index);
+            newSpell.GetComponent<Button>().onClick.AddListener(() => GetIndex(newSpell));
+
+            queue[index] = newSpell;
+        }
+        else if (SpellChance > CommonRarityChance && SpellChance < (100 - RareRarityChance))
+        {
+            randomIndex = Random.Range(0, UncommonSpellButtons.Length);
+            newSpell = Instantiate(UncommonSpellButtons[randomIndex], position, Quaternion.identity) as GameObject;
+            newSpell.transform.SetParent(spellQueue.transform, false);
+
+            //Add Click Listener
+            newSpell.GetComponent<Button>().onClick.AddListener(() => OnClickSpellUncommon(randomIndex));
+            newSpell.GetComponent<ButtonIndex>().ButtonIndexing(index);
+            newSpell.GetComponent<Button>().onClick.AddListener(() => GetIndex(newSpell));
+
+            queue[index] = newSpell;
+        }
+        else if (SpellChance >= (CommonRarityChance + UncommonRarityChance))
+        {
+            randomIndex = Random.Range(0, RareSpellButtons.Length);
+            newSpell = Instantiate(RareSpellButtons[randomIndex], position, Quaternion.identity) as GameObject;
+            newSpell.transform.SetParent(spellQueue.transform, false);
+
+            //Add Click Listener
+            newSpell.GetComponent<Button>().onClick.AddListener(() => OnClickSpellRare(randomIndex));
+            newSpell.GetComponent<ButtonIndex>().ButtonIndexing(index);
+            newSpell.GetComponent<Button>().onClick.AddListener(() => GetIndex(newSpell));
+
+            queue[index] = newSpell;
+        }
     }
 
     //Called on start only now
@@ -504,17 +575,49 @@ public class CastSpell : MonoBehaviour
         {
             if (queue[i] == null)
             {
-                int random = Random.Range(0, spellButtons.Length);
-                GameObject newSpell = Instantiate(spellButtons[random], new Vector3(100f + 40f * i, 20f, 0), Quaternion.identity) as GameObject;
-                newSpell.transform.SetParent(spellQueue.transform, false);
+                int randomIndex;
+                GameObject newSpell;
+                int SpellChance = Random.Range(1, 100);
 
+                if (SpellChance <= CommonRarityChance)
+                {
+                    randomIndex = Random.Range(0, CommonSpellButtons.Length);
+                    newSpell = Instantiate(CommonSpellButtons[randomIndex], new Vector3(100f + 40f * i, 20f, 0), Quaternion.identity) as GameObject;
+                    newSpell.transform.SetParent(spellQueue.transform, false);
 
-                //Add click listeners for all trap buttons
-                newSpell.GetComponent<Button>().onClick.AddListener(() => OnClickSpell(random));
-                newSpell.GetComponent<ButtonIndex>().ButtonIndexing(i);
-                newSpell.GetComponent<Button>().onClick.AddListener(() => GetIndex(newSpell));
+                    //Add Click Listener
+                    newSpell.GetComponent<Button>().onClick.AddListener(() => OnClickSpellCommon(randomIndex));
+                    newSpell.GetComponent<ButtonIndex>().ButtonIndexing(i);
+                    newSpell.GetComponent<Button>().onClick.AddListener(() => GetIndex(newSpell));
 
-                queue[i] = newSpell;
+                    queue[i] = newSpell;
+                }
+                else if (SpellChance > CommonRarityChance && SpellChance < (100 - RareRarityChance))
+                {
+                    randomIndex = Random.Range(0, UncommonSpellButtons.Length);
+                    newSpell = Instantiate(UncommonSpellButtons[randomIndex], new Vector3(100f + 40f * i, 20f, 0), Quaternion.identity) as GameObject;
+                    newSpell.transform.SetParent(spellQueue.transform, false);
+
+                    //Add Click Listener
+                    newSpell.GetComponent<Button>().onClick.AddListener(() => OnClickSpellUncommon(randomIndex));
+                    newSpell.GetComponent<ButtonIndex>().ButtonIndexing(i);
+                    newSpell.GetComponent<Button>().onClick.AddListener(() => GetIndex(newSpell));
+
+                    queue[i] = newSpell;
+                }
+                else if (SpellChance >= (CommonRarityChance + UncommonRarityChance))
+                {
+                    randomIndex = Random.Range(0, RareSpellButtons.Length);
+                    newSpell = Instantiate(RareSpellButtons[randomIndex], new Vector3(100f + 40f * i, 20f, 0), Quaternion.identity) as GameObject;
+                    newSpell.transform.SetParent(spellQueue.transform, false);
+
+                    //Add Click Listener
+                    newSpell.GetComponent<Button>().onClick.AddListener(() => OnClickSpellRare(randomIndex));
+                    newSpell.GetComponent<ButtonIndex>().ButtonIndexing(i);
+                    newSpell.GetComponent<Button>().onClick.AddListener(() => GetIndex(newSpell));
+
+                    queue[i] = newSpell;
+                }
             }
         }
     }

--- a/Assets/Scripts/Players/PlaceTrap.cs
+++ b/Assets/Scripts/Players/PlaceTrap.cs
@@ -16,11 +16,25 @@ public class PlaceTrap : MonoBehaviour {
     [Header("Design Values -------------")]
     [SerializeField] private int gridSize;
 
+    [Header("Percentage is X/100 currently.")]
+    [SerializeField] private int CommonRarityChance = 50;
+    [SerializeField] private int UncommonRarityChance = 35;
+    [SerializeField] private int RareRarityChance = 15;
+
     [Header("Programmers - GameObjects/Scripts -----")]
     [SerializeField] private GameObject tower;
 
-    [SerializeField] private GameObject[] trapButtons;
-    [SerializeField] private TrapBase[] trapPrefabs;
+    // [SerializeField] private GameObject[] trapButtons;
+     //[SerializeField] private TrapBase[] trapPrefabs;
+
+    [SerializeField] private GameObject[] CommonTrapButtons;
+    [SerializeField] private GameObject[] UncommonTrapButtons;
+    [SerializeField] private GameObject[] RareTrapButtons;
+
+    [SerializeField] private TrapBase[] CommonTrapPrefabs;
+    [SerializeField] private TrapBase[] UncommonTrapPrefabs;
+    [SerializeField] private TrapBase[] RareTrapPrefabs;
+
     [SerializeField] private GameObject trapQueue;
 
     [SerializeField] private Image controllerCursor;
@@ -542,9 +556,32 @@ public class PlaceTrap : MonoBehaviour {
     }
 
     //Called from trap button / CallClick script
-    public void OnClickTrap(int trapNum)
+    public void OnClickTrapCommon(int trapNum)
     {
-        trap = trapPrefabs[trapNum];
+        trap = CommonTrapPrefabs[trapNum];
+
+        trapRot = 0;
+        StartCoroutine(EnableInput());
+        DestroyGhost();
+        GetComponent<CastSpell>().DestroyTarget();
+        SetGhost();
+    }
+
+    public void OnClickTrapUncommon(int trapNum)
+    {
+        trap = UncommonTrapPrefabs[trapNum];
+
+        trapRot = 0;
+        StartCoroutine(EnableInput());
+        DestroyGhost();
+        GetComponent<CastSpell>().DestroyTarget();
+        SetGhost();
+    }
+
+    public void OnClickTrapRare(int trapNum)
+    {
+        trap = RareTrapPrefabs[trapNum];
+
         trapRot = 0;
         StartCoroutine(EnableInput());
         DestroyGhost();
@@ -582,16 +619,56 @@ public class PlaceTrap : MonoBehaviour {
         active = true;
         for(int i = 0; i < queueSize; i++)
         {
-            int random = Random.Range(0, trapButtons.Length);
-            GameObject newTrap = Instantiate(trapButtons[random], new Vector3 (-230f + 40f*i, -30, 0), Quaternion.identity) as GameObject;
-            newTrap.transform.SetParent(trapQueue.transform, false);
+           int TrapChance = Random.Range(1, 100);
+           int randomIndex;
+           GameObject newTrap;
 
-            //Add click listeners for all trap buttons
-            newTrap.GetComponent<Button>().onClick.AddListener(() => OnClickTrap(random));
-            newTrap.GetComponent<ButtonIndex>().ButtonIndexing(i);
-            newTrap.GetComponent<Button>().onClick.AddListener(() => GetIndex(newTrap));
+            if (TrapChance <= CommonRarityChance)
+            {
+                randomIndex = Random.Range(0, CommonTrapButtons.Length);
+                newTrap = Instantiate(CommonTrapButtons[randomIndex], new Vector3(-230f + 40f * i, -30, 0), Quaternion.identity) as GameObject;
 
-            queue.Add(newTrap);
+                newTrap.transform.SetParent(trapQueue.transform, false);
+
+                //Add click listeners for all trap buttons
+                newTrap.GetComponent<Button>().onClick.AddListener(() => OnClickTrapCommon(randomIndex));
+                newTrap.GetComponent<ButtonIndex>().ButtonIndexing(i);
+                newTrap.GetComponent<Button>().onClick.AddListener(() => GetIndex(newTrap));
+
+                queue.Add(newTrap);
+            }
+            else if (TrapChance > CommonRarityChance && TrapChance < (100 - RareRarityChance))
+            {
+                randomIndex = Random.Range(0, UncommonTrapButtons.Length);
+                newTrap = Instantiate(UncommonTrapButtons[randomIndex], new Vector3(-230f + 40f * i, -30, 0), Quaternion.identity) as GameObject;
+
+                newTrap.transform.SetParent(trapQueue.transform, false);
+
+                //Add click listeners for all trap buttons
+                newTrap.GetComponent<Button>().onClick.AddListener(() => OnClickTrapUncommon(randomIndex));
+                newTrap.GetComponent<ButtonIndex>().ButtonIndexing(i);
+                newTrap.GetComponent<Button>().onClick.AddListener(() => GetIndex(newTrap));
+
+                queue.Add(newTrap);
+            }
+            else if (TrapChance >= (CommonRarityChance + UncommonRarityChance))
+            {
+                randomIndex = Random.Range(0, RareTrapButtons.Length);
+                newTrap = Instantiate(RareTrapButtons[randomIndex], new Vector3(-230f + 40f * i, -30, 0), Quaternion.identity) as GameObject;
+
+                newTrap.transform.SetParent(trapQueue.transform, false);
+
+                //Add click listeners for all trap buttons
+                newTrap.GetComponent<Button>().onClick.AddListener(() => OnClickTrapRare(randomIndex));
+                newTrap.GetComponent<ButtonIndex>().ButtonIndexing(i);
+                newTrap.GetComponent<Button>().onClick.AddListener(() => GetIndex(newTrap));
+
+                queue.Add(newTrap);
+            }
+            else
+            {
+                Debug.Log("Error. You weren't supposed to reach here.");
+            }
 
             if (active == false)
             {


### PR DESCRIPTION
Trap and spell rarity has been added. Default chances for both are 50 - 35 - 15. 
50% for Common Traps/Spells.
35% for the medium chance traps/spells.
15% for the low chance traps/spells.

Can change the numbers in Player 2. Make sure they add up to 100.

Can add multiple copies of a trap or spell to increase their chance of showing up in a certain bucket.

Delete branch.