### PR TITLE
Player Quality of Life Changes

### DIFF
--- a/Assets/Animations/TestAnimator.controller
+++ b/Assets/Animations/TestAnimator.controller
@@ -13,73 +13,73 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Jumping
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
-    m_DefaultBool: 1
-    m_Controller: {fileID: 9100000}
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   - m_Name: Running
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Landing
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Grounded
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: YVelocity
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Knockback
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Stunned
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: StunAnimSpeed
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Slowed
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Crouched
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
-    m_DefaultBool: 1
-    m_Controller: {fileID: 9100000}
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   - m_Name: WallJump
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -904,7 +904,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: Landing
+    m_ConditionEvent: Grounded
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1102545039245963118}
@@ -2261,6 +2261,30 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &1101712972194614164
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Grounded
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102545039245963118}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.67391306
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &1101713219586685384
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -3253,11 +3277,12 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: Armature|JumpStart
-  m_Speed: 2
+  m_Speed: 2.5
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 1101821583771679986}
   - {fileID: 1101846174019692268}
+  - {fileID: 1101712972194614164}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -3416,7 +3441,7 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: Armature|JumpEnd
-  m_Speed: 2
+  m_Speed: 2.5
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 1101310769880540024}
@@ -3681,7 +3706,7 @@ AnimatorStateMachine:
     m_Position: {x: 312, y: 408, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102357195585846258}
-    m_Position: {x: 672, y: 780, z: 0}
+    m_Position: {x: 564, y: 888, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102100714422336092}
     m_Position: {x: 864, y: 588, z: 0}

--- a/Assets/Models/Characters/Character_Speccy_Clothed.fbx.meta
+++ b/Assets/Models/Characters/Character_Speccy_Clothed.fbx.meta
@@ -167,7 +167,7 @@ ModelImporter:
     - serializedVersion: 16
       name: Armature|CrouchEnd
       takeName: Armature|CrouchEnd
-      firstFrame: 1
+      firstFrame: 5
       lastFrame: 34
       wrapMode: 0
       orientationOffsetY: 0

--- a/Assets/Models/Characters/Character_Speccy_Clothed.fbx.meta
+++ b/Assets/Models/Characters/Character_Speccy_Clothed.fbx.meta
@@ -468,7 +468,7 @@ ModelImporter:
     - serializedVersion: 16
       name: Armature|JumpIdle
       takeName: Armature|JumpIdle
-      firstFrame: 0
+      firstFrame: 1
       lastFrame: 12
       wrapMode: 0
       orientationOffsetY: 0

--- a/Assets/Prefabs/Players and Cameras/Player 1.prefab
+++ b/Assets/Prefabs/Players and Cameras/Player 1.prefab
@@ -1944,7 +1944,7 @@ MonoBehaviour:
   - {fileID: 0}
   pickupEmpty: {fileID: 21300000, guid: ece564ad1c3aa22429a5b4a98135c9bd, type: 3}
   cam: {fileID: 114614076012222384}
-  distanceFromGround: 0.1
+  distanceFromGround: 0.05
   gameManager: {fileID: 0}
   speedBoostSFX: {fileID: 8300000, guid: e06853b6be043644f89a1ab20dc6cbe8, type: 3}
 --- !u!135 &135254525513457034

--- a/Assets/Prefabs/Players and Cameras/Player 1.prefab
+++ b/Assets/Prefabs/Players and Cameras/Player 1.prefab
@@ -1944,7 +1944,6 @@ MonoBehaviour:
   - {fileID: 0}
   pickupEmpty: {fileID: 21300000, guid: ece564ad1c3aa22429a5b4a98135c9bd, type: 3}
   cam: {fileID: 114614076012222384}
-  distanceFromGround: 0.05
   gameManager: {fileID: 0}
   speedBoostSFX: {fileID: 8300000, guid: e06853b6be043644f89a1ab20dc6cbe8, type: 3}
 --- !u!135 &135254525513457034
@@ -2021,7 +2020,7 @@ CapsuleCollider:
   m_Radius: 1.1501592
   m_Height: 4
   m_Direction: 1
-  m_Center: {x: 2.4990276e-15, y: 2.2, z: 0.20756459}
+  m_Center: {x: 0, y: 2.2, z: 0.21}
 --- !u!137 &137489807720363134
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Players and Cameras/Player 1.prefab
+++ b/Assets/Prefabs/Players and Cameras/Player 1.prefab
@@ -1846,7 +1846,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 573825152f644014eaa6302b43f5365f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  timer: {fileID: 0}
+  vines: {fileID: 0}
 --- !u!114 &114614076012222384
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1864,8 +1864,11 @@ MonoBehaviour:
   playerOneCam: {fileID: 0}
   cinemachineSpeccy: {fileID: 0}
   moveSpeed: 0.75
+  moveUpSlowMultiplier: 1.7
+  zoomOutAmount: 35
   playerModel: {fileID: 1428506183960842}
   vcamLock: {fileID: 0}
+  cameraTarget: {fileID: 1428506183960842}
   rotateTriggers:
   - {fileID: 0}
   - {fileID: 0}
@@ -1935,9 +1938,15 @@ MonoBehaviour:
   wallJumpDivider: 1.6
   wallJumpDirectionDivider: 0.75
   InputEnabled: 1
+  pickupImages:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  pickupEmpty: {fileID: 21300000, guid: ece564ad1c3aa22429a5b4a98135c9bd, type: 3}
   cam: {fileID: 114614076012222384}
   distanceFromGround: 0.1
   gameManager: {fileID: 0}
+  speedBoostSFX: {fileID: 8300000, guid: e06853b6be043644f89a1ab20dc6cbe8, type: 3}
 --- !u!135 &135254525513457034
 SphereCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -282,13 +282,13 @@ public class PlayerOneMovement : MonoBehaviour {
         }
 
         //WallJump Check at feet
-        Debug.DrawRay(transform.position, transform.forward, Color.green);
+        //Debug.DrawRay(transform.position, transform.forward, Color.green);
         //WallJump Check at knee
-        Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 1, transform.position.z), transform.forward, Color.blue);
+        //Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 1, transform.position.z), transform.forward, Color.blue);
         //WallJump Check at chest
-        Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 2, transform.position.z), transform.forward, Color.red);
+        //Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 2, transform.position.z), transform.forward, Color.red);
         //WallJump Check at nose/head
-        Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 3, transform.position.z), transform.forward, Color.yellow);
+        //Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 3, transform.position.z), transform.forward, Color.yellow);
 
         //Distance from feet to platform
         //Debug.DrawRay(transform.position, -transform.up, Color.yellow, distanceFromGround);

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -283,6 +283,11 @@ public class PlayerOneMovement : MonoBehaviour {
         Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 2, transform.position.z), transform.forward, Color.red);
         //WallJump Check at nose/head
         Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 3, transform.position.z), transform.forward, Color.yellow);
+
+        animator.SetBool("Landing", landing);
+        animator.SetBool("Grounded", grounded);
+        animator.SetBool("Crouched", crouching);
+        animator.SetFloat("YVelocity", rb.velocity.y);
     }
 
 
@@ -300,7 +305,7 @@ public class PlayerOneMovement : MonoBehaviour {
             jumping = false;
             landing = false;
             speed = (moveSpeed * SlowPenaltyTier1 * StunPenalty * CrouchPenalty) * SuperSpeed;
-            CheckLanding();
+            StartCoroutine(CheckLanding());
         }
         else if (crouching)
         {
@@ -340,10 +345,6 @@ public class PlayerOneMovement : MonoBehaviour {
             }
             //NOT WALL JUMPING
         }
-        animator.SetBool("Landing", landing);
-        animator.SetBool("Grounded", grounded);
-        animator.SetBool("Crouched", crouching);
-        animator.SetFloat("YVelocity", rb.velocity.y);
     }
 
     private IEnumerator DisableWallJump()
@@ -381,21 +382,23 @@ public class PlayerOneMovement : MonoBehaviour {
         gameObject.GetComponent<PlayerOneStats>().pickupCount = 0;
     }
 
-    private void CheckLanding()
+    private IEnumerator CheckLanding()
     {
         while (landing == false)
         {
             RaycastHit hit;
-            if (Physics.Raycast(transform.position, -transform.up, out hit, LayerMask.GetMask("Platform")) && grounded == false)
+            if ((Physics.Raycast(transform.position, -transform.up, out hit, LayerMask.GetMask("Platform")) || 
+                Physics.Raycast(transform.position, -transform.up, out hit, LayerMask.GetMask("Trap"))) && grounded == false)
             {
                 Debug.DrawRay(transform.position, -transform.up, Color.yellow);
-                if (hit.distance <= distanceFromGround && jumping == false)
+                if (hit.distance <= distanceFromGround)
                 {
+                    Debug.Log(hit.distance);
                     landing = true;
                 }
             }
+            yield return null;
         }
-        landing = false;
     }
 
     /////////////////////////////////////////////

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -45,7 +45,7 @@ public class PlayerOneMovement : MonoBehaviour {
 
     //camera
     [SerializeField] private CameraOneRotator cam;
-    [SerializeField] private float distanceFromGround = 2f;
+    //[SerializeField] private float distanceFromGround = 2f;
     private int camOneState = 1;
 
     [SerializeField] private GameObject gameManager;
@@ -284,7 +284,9 @@ public class PlayerOneMovement : MonoBehaviour {
         //WallJump Check at nose/head
         Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 3, transform.position.z), transform.forward, Color.yellow);
 
-        animator.SetBool("Landing", landing);
+        //Distance from feet to platform
+        //Debug.DrawRay(transform.position, -transform.up, Color.yellow, distanceFromGround);
+
         animator.SetBool("Grounded", grounded);
         animator.SetBool("Crouched", crouching);
         animator.SetFloat("YVelocity", rb.velocity.y);
@@ -303,9 +305,10 @@ public class PlayerOneMovement : MonoBehaviour {
                 animator.Play("Armature|JumpStart", 0);
             }
             jumping = false;
-            landing = false;
+           //landing = false;
             speed = (moveSpeed * SlowPenaltyTier1 * StunPenalty * CrouchPenalty) * SuperSpeed;
-            StartCoroutine(CheckLanding());
+            //animator.SetBool("Landing", landing);
+            //StartCoroutine(CheckLanding());
         }
         else if (crouching)
         {
@@ -382,24 +385,19 @@ public class PlayerOneMovement : MonoBehaviour {
         gameObject.GetComponent<PlayerOneStats>().pickupCount = 0;
     }
 
-    private IEnumerator CheckLanding()
+   /* private IEnumerator CheckLanding()
     {
         while (landing == false)
         {
             RaycastHit hit;
-            if ((Physics.Raycast(transform.position, -transform.up, out hit, LayerMask.GetMask("Platform")) || 
-                Physics.Raycast(transform.position, -transform.up, out hit, LayerMask.GetMask("Trap"))) && grounded == false)
+            if (Physics.Raycast(transform.position, -transform.up, out hit, distanceFromGround) && grounded == false)
             {
-                Debug.DrawRay(transform.position, -transform.up, Color.yellow);
-                if (hit.distance <= distanceFromGround)
-                {
-                    Debug.Log(hit.distance);
-                    landing = true;
-                }
+                landing = true;
+                animator.SetBool("Landing", landing);
             }
             yield return null;
         }
-    }
+    }*/
 
     /////////////////////////////////////////////
     // GETTERS AND SETTERS                     //

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -62,8 +62,9 @@ public class PlayerOneMovement : MonoBehaviour {
     private PauseMenu pause;
     private Animator animator;
     private CapsuleCollider col;
+    private CapsuleCollider[] colArray;
     private ParticleSystemRenderer stun;
-    private SphereCollider sphere;
+    private SphereCollider[] sphere;
 
     private void Awake()
     {
@@ -76,9 +77,10 @@ public class PlayerOneMovement : MonoBehaviour {
         animator = GetComponent<Animator>();
         //checkControllers = gameManager.GetComponent<CheckControllers>();
         col = GetComponent<CapsuleCollider>();
+        colArray = GetComponents<CapsuleCollider>();
         stun = GetComponentInChildren<ParticleSystemRenderer>();
         pause = gameManager.GetComponent<PauseMenu>();
-        sphere = GetComponent<SphereCollider>();
+        sphere = GetComponents<SphereCollider>();
         stun.enabled = false;
         crouching = false;
         animator.SetBool("Grounded", grounded);
@@ -243,13 +245,17 @@ public class PlayerOneMovement : MonoBehaviour {
             CrouchPenalty = crouchSlow;
             col.height = 2.25f;
             col.center = new Vector3(0, 1.1f, 0);
-            sphere.center = new Vector3(0, 1f, 0); 
+            colArray[1].height = 2f;
+            colArray[1].center = new Vector3(0, 1f, 0.21f);
+            sphere[0].center = new Vector3(0, 1f, 0); 
         }
 
         if(crouching == false || grounded == false) {
             col.height = 4.5f;
             col.center = new Vector3(0, 2.2f, 0);
-            sphere.center = new Vector3(0, 3f, 0);
+            colArray[1].height = 4f;
+            colArray[1].center = new Vector3(0, 2.2f, 0.21f);
+            sphere[0].center = new Vector3(0, 3f, 0);
         }
 
         cantStandUp = gameObject.GetComponentInChildren<Colliding>().GetCollision();

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -274,6 +274,15 @@ public class PlayerOneMovement : MonoBehaviour {
         {
             StunPenalty = 1;
         }
+
+        //WallJump Check at feet
+        Debug.DrawRay(transform.position, transform.forward, Color.green);
+        //WallJump Check at knee
+        Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 1, transform.position.z), transform.forward, Color.blue);
+        //WallJump Check at chest
+        Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 2, transform.position.z), transform.forward, Color.red);
+        //WallJump Check at nose/head
+        Debug.DrawRay(new Vector3(transform.position.x, transform.position.y + 3, transform.position.z), transform.forward, Color.yellow);
     }
 
 
@@ -291,6 +300,7 @@ public class PlayerOneMovement : MonoBehaviour {
             jumping = false;
             landing = false;
             speed = (moveSpeed * SlowPenaltyTier1 * StunPenalty * CrouchPenalty) * SuperSpeed;
+            CheckLanding();
         }
         else if (crouching)
         {
@@ -303,26 +313,7 @@ public class PlayerOneMovement : MonoBehaviour {
         }
 
         if (!wallJumping) rb.velocity = movementVector;
-        else rb.velocity = wallJumpVector;
-
-        RaycastHit hit;
-        if (Physics.Raycast(transform.position, transform.TransformDirection(Vector3.down), out hit, LayerMask.GetMask("Platform")) && grounded == false)
-        {
-            Debug.DrawRay(transform.position, transform.TransformDirection(Vector3.down) * distanceFromGround, Color.yellow);
-            if (hit.distance <= distanceFromGround && jumping == false)
-            {
-                landing = true;
-            }
-            if (hit.distance > distanceFromGround)
-            {
-                landing = false;
-            }
-        }
-
-        if(grounded == true)
-        {
-            landing = true;
-        }
+        else rb.velocity = wallJumpVector;      
     }
 
 
@@ -334,7 +325,9 @@ public class PlayerOneMovement : MonoBehaviour {
             RaycastHit hit;
             RaycastHit downHit;
             bool raycastDown = Physics.Raycast(transform.position, -transform.up, out downHit, 1);
-            if (Physics.Raycast(transform.position, transform.forward, out hit, 1.5f) && !raycastDown)
+            if ((Physics.Raycast(transform.position, transform.forward, out hit, 1.5f) || Physics.Raycast(new Vector3(transform.position.x, transform.position.y + 1, transform.position.z), transform.forward, out hit, 1.5f) || 
+                    Physics.Raycast(new Vector3(transform.position.x, transform.position.y + 2, transform.position.z), transform.forward, out hit, 1.5f) 
+                    || Physics.Raycast(new Vector3(transform.position.x, transform.position.y + 1, transform.position.z), transform.forward, out hit, 1.5f)) && !raycastDown)
             {
                 if (hit.transform.tag == "Platform" && inputManager.GetButtonDown(InputCommand.BottomPlayerJump) && grounded == false && move == true)
                 {
@@ -386,6 +379,23 @@ public class PlayerOneMovement : MonoBehaviour {
         spedUp = false;
         SuperSpeed = 1;
         gameObject.GetComponent<PlayerOneStats>().pickupCount = 0;
+    }
+
+    private void CheckLanding()
+    {
+        while (landing == false)
+        {
+            RaycastHit hit;
+            if (Physics.Raycast(transform.position, -transform.up, out hit, LayerMask.GetMask("Platform")) && grounded == false)
+            {
+                Debug.DrawRay(transform.position, -transform.up, Color.yellow);
+                if (hit.distance <= distanceFromGround && jumping == false)
+                {
+                    landing = true;
+                }
+            }
+        }
+        landing = false;
     }
 
     /////////////////////////////////////////////


### PR DESCRIPTION
Branched of woosh sfx fix.

Player wall jumps now checks at 4 different heights compared to the one before. Used to only check near the feet. Now checks at feet, at thighs/knees, at chest, and at eyes. Can remove some checks if desired.

Made landing animation line up better with model actually near ground.

Removed a frame in jump idle so arms don't awkwardly jump around.

Removed some frames from crouch end so it goes from crouch to stand instead of stand to crouch to stand.

Moved animator setters in PlayerOneMovement to the correct function -> Update()

Fixed player hitboxes when crouching so player can crouch beneath arrows fired at eye level when standing.

Delete branch.