### PR TITLE
Fixes

### DIFF
--- a/Assets/Prefabs/Resources/LogProjectile.prefab
+++ b/Assets/Prefabs/Resources/LogProjectile.prefab
@@ -26,7 +26,7 @@ GameObject:
   - component: {fileID: 114256166817004388}
   m_Layer: 19
   m_Name: Log Model
-  m_TagString: Untagged
+  m_TagString: Projectile
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Traps/LogRollerTrap.prefab
+++ b/Assets/Prefabs/Traps/LogRollerTrap.prefab
@@ -95,7 +95,7 @@ GameObject:
   - component: {fileID: 114832420465715662}
   m_Layer: 0
   m_Name: LogRollerTrap
-  m_TagString: Trap
+  m_TagString: TrapHitbox
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Traps/LogRollerTrap.prefab
+++ b/Assets/Prefabs/Traps/LogRollerTrap.prefab
@@ -300,7 +300,7 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 2, y: 2, z: 4}
-  m_Center: {x: -0.02, y: 0.62, z: 0}
+  m_Center: {x: -0.02, y: 0.1, z: 0}
 --- !u!65 &65115508649182200
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -323,8 +323,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.02018228, y: 0.04000001, z: 0.05455992}
-  m_Center: {x: 0.00029235007, y: -4.3076072e-17, z: 0.021720046}
+  m_Size: {x: 0.019, y: 0.04000001, z: 0.05455992}
+  m_Center: {x: 0.0002, y: -4.3076072e-17, z: 0.021720046}
 --- !u!114 &114105927209140518
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Players/Colliding.cs
+++ b/Assets/Scripts/Players/Colliding.cs
@@ -12,7 +12,7 @@ public class Colliding : MonoBehaviour {
 
     private void OnTriggerStay(Collider other)
     {
-        if(other.tag == "Platform")
+        if(other.tag == "Platform" || other.tag == "TrapHitBox")
         {
             collided = true;
         }
@@ -20,7 +20,7 @@ public class Colliding : MonoBehaviour {
 
     private void OnTriggerExit(Collider other)
     {
-        if (other.tag == "Platform")
+        if (other.tag == "Platform" || other.tag == "TrapHitBox")
         {
             collided = false;
         }

--- a/Assets/Scripts/Players/Colliding.cs
+++ b/Assets/Scripts/Players/Colliding.cs
@@ -12,7 +12,7 @@ public class Colliding : MonoBehaviour {
 
     private void OnTriggerStay(Collider other)
     {
-        if(other.tag == "Platform" || other.tag == "TrapHitBox")
+        if(other.tag == "Platform" || other.tag == "TrapHitbox")
         {
             collided = true;
         }
@@ -20,7 +20,7 @@ public class Colliding : MonoBehaviour {
 
     private void OnTriggerExit(Collider other)
     {
-        if (other.tag == "Platform" || other.tag == "TrapHitBox")
+        if (other.tag == "Platform" || other.tag == "TrapHitbox")
         {
             collided = false;
         }

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -68,7 +68,7 @@ public class PlayerOneMovement : MonoBehaviour {
     private Animator animator;
     private CapsuleCollider col;
     private CapsuleCollider[] colArray;
-    
+
     private SphereCollider[] sphere;
     private GhostTrail ghost;
     private bool once = false;
@@ -126,15 +126,15 @@ public class PlayerOneMovement : MonoBehaviour {
             {
                 slowSwirl = p;
             }
-            if(p.name == "Stun Particles")
+            if (p.name == "Stun Particles")
             {
                 stun = p;
             }
-            if(p.name == "blue swirls")
+            if (p.name == "blue swirls")
             {
                 speedUpSwirl = p;
             }
-            if(p.name == "Beams")
+            if (p.name == "Beams")
             {
                 speedUpBeams = p;
             }
@@ -193,7 +193,7 @@ public class PlayerOneMovement : MonoBehaviour {
                 jumping = true;
             }
 
-            if(inputManager.GetButtonDown(InputCommand.BottomPlayerJump) && grounded && crouching == true && cantStandUp == false)
+            if (inputManager.GetButtonDown(InputCommand.BottomPlayerJump) && grounded && crouching == true && cantStandUp == false)
             {
                 jumping = true;
             }
@@ -215,7 +215,7 @@ public class PlayerOneMovement : MonoBehaviour {
                     crouching = false;
                     CrouchPenalty = 1;
                 }
-                
+
             }
             // Animation parameters update
             animator.SetBool("Jumping", jumping);
@@ -325,10 +325,10 @@ public class PlayerOneMovement : MonoBehaviour {
             col.center = new Vector3(0, 1.1f, 0);
             colArray[1].height = 2f;
             colArray[1].center = new Vector3(0, 1f, 0.21f);
-            sphere[0].center = new Vector3(0, 1f, 0); 
+            sphere[0].center = new Vector3(0, 1f, 0);
         }
 
-        if(crouching == false || grounded == false) {
+        if (crouching == false || grounded == false) {
             col.height = 4.5f;
             col.center = new Vector3(0, 2.2f, 0);
             colArray[1].height = 4f;
@@ -338,16 +338,16 @@ public class PlayerOneMovement : MonoBehaviour {
 
         cantStandUp = gameObject.GetComponentInChildren<Colliding>().GetCollision();
 
-        if(!pause.GameIsPaused) Move();
+        if (!pause.GameIsPaused) Move();
 
-        if(spedUp == false && GameObject.FindWithTag("Player").GetComponent<PlayerOneStats>().pickupCount >= 3)
+        if (spedUp == false && GameObject.FindWithTag("Player").GetComponent<PlayerOneStats>().pickupCount >= 3)
         {
             speedUpBeams.enabled = true;
             speedUpSwirl.enabled = true;
         }
 
         // initiate speed up
-            if (GameObject.FindWithTag("Player").GetComponent<PlayerOneStats>().pickupCount >= 3 && inputManager.GetButtonDown(InputCommand.BottomPlayerBoost) && once == false)
+        if (GameObject.FindWithTag("Player").GetComponent<PlayerOneStats>().pickupCount >= 3 && inputManager.GetButtonDown(InputCommand.BottomPlayerBoost) && once == false)
         {
             spedUp = true;
             audioSource.PlayOneShot(speedBoostSFX);
@@ -380,7 +380,7 @@ public class PlayerOneMovement : MonoBehaviour {
             unSlow = true;
         }
 
-        if(unSlow == false)
+        if (unSlow == false)
         {
             slowSwirl.enabled = true;
             slowAura.enabled = true;
@@ -391,7 +391,7 @@ public class PlayerOneMovement : MonoBehaviour {
             slowAura.enabled = false;
         }
 
-        if(slowed == true)
+        if (slowed == true)
         {
             if (sap == false)
             {
@@ -435,7 +435,7 @@ public class PlayerOneMovement : MonoBehaviour {
                 animator.Play("Armature|JumpStart", 0);
             }
             jumping = false;
-           //landing = false;
+            //landing = false;
             speed = (moveSpeed * SlowPenaltyTier1 * StunPenalty * CrouchPenalty) * SuperSpeed;
             //animator.SetBool("Landing", landing);
             //StartCoroutine(CheckLanding());
@@ -456,17 +456,18 @@ public class PlayerOneMovement : MonoBehaviour {
         }
 
         if (!wallJumping) rb.velocity = movementVector;
-        else rb.velocity = wallJumpVector;      
+        else rb.velocity = wallJumpVector;
     }
 
 
     private void OnTriggerStay(Collider collision)
     {
-        if (collision.gameObject.tag == "Platform" || collision.gameObject.tag == "Trap")
+        if (collision.gameObject.tag == "Platform" || collision.gameObject.tag == "Trap" || collision.gameObject.tag == "TrapHitbox")
         {
             //CHECK WALL JUMP
             RaycastHit hit;
             RaycastHit downHit;
+            Debug.Log(collision);
             bool raycastDown = Physics.Raycast(transform.position, -transform.up, out downHit, 1);
             if ((Physics.Raycast(new Vector3(transform.position.x, transform.position.y + 0.5f, transform.position.z), transform.forward, out hit, 2f) || Physics.Raycast(new Vector3(transform.position.x, transform.position.y + 1, transform.position.z), transform.forward, out hit, 2f) || 
                     Physics.Raycast(new Vector3(transform.position.x, transform.position.y + 2, transform.position.z), transform.forward, out hit, 2f) 

--- a/Assets/Scripts/Spells/BallandChain.cs
+++ b/Assets/Scripts/Spells/BallandChain.cs
@@ -93,7 +93,7 @@ public class BallandChain : MonoBehaviour {
     private IEnumerator Wait(GameObject obj)
     {
         yield return new WaitForSeconds(spellDuration);
-        yield return new WaitForSeconds(1f);
+        yield return new WaitForSeconds(spellDuration*4f);
         Destroy(obj);
     }
 
@@ -105,7 +105,7 @@ public class BallandChain : MonoBehaviour {
 
     private IEnumerator DestroyObj()
     {
-        yield return new WaitForSeconds(spellDuration + 2f);
+        yield return new WaitForSeconds(spellDuration*4f);
         Destroy(this.gameObject);
     }
 }

--- a/Assets/Scripts/Spells/BallandChain.cs
+++ b/Assets/Scripts/Spells/BallandChain.cs
@@ -92,7 +92,6 @@ public class BallandChain : MonoBehaviour {
 
     private IEnumerator Wait(GameObject obj)
     {
-        yield return new WaitForSeconds(spellDuration);
         yield return new WaitForSeconds(spellDuration*4f);
         Destroy(obj);
     }

--- a/Assets/Scripts/Spells/Petrify.cs
+++ b/Assets/Scripts/Spells/Petrify.cs
@@ -60,7 +60,6 @@ public class Petrify : MonoBehaviour {
             {
                 child = player.GetComponentsInChildren<Renderer>();
                 spellBase.Stun(player, stunDuration, turnStone);
-                anim.enabled = false;
                 StartCoroutine(CheckPetrifyStatus());
                 StartCoroutine(Wait(this.gameObject));
             }
@@ -81,6 +80,7 @@ public class Petrify : MonoBehaviour {
             hit = true;
             player = other.gameObject;
             anim = player.gameObject.GetComponent<PlayerOneMovement>().GetAnim();
+            anim.enabled = false;
 
             //Turn off renderer & particles
             this.GetComponent<Renderer>().enabled = false;
@@ -122,6 +122,7 @@ public class Petrify : MonoBehaviour {
                 r.material = normalPoncho;
             }
         }
+        anim.enabled = true;
     }
 
     private IEnumerator Wait(GameObject obj)
@@ -136,7 +137,7 @@ public class Petrify : MonoBehaviour {
             }
             yield return null;
         }
-        yield return new WaitForSeconds(2f);
+        yield return new WaitForSeconds(8f);
         Destroy(obj);
     }
 
@@ -148,7 +149,7 @@ public class Petrify : MonoBehaviour {
 
     private IEnumerator Die(float time)
     {
-        yield return new WaitForSeconds(time);
+        yield return new WaitForSeconds(time * 4);
         Destroy(this.gameObject);
     }
 

--- a/Assets/Scripts/Traps/Banana.cs
+++ b/Assets/Scripts/Traps/Banana.cs
@@ -16,6 +16,8 @@ public class Banana : MonoBehaviour {
     private GameObject player = null;
     // Player's animator for animation
     private Animator anim = null;
+    //trap's collider
+    private BoxCollider box;
 
     // SFX
     private AudioSource audioSource;
@@ -27,6 +29,7 @@ public class Banana : MonoBehaviour {
         trapBase = GetComponent<TrapBase>();
         audioSource = GetComponent<AudioSource>();
         thisAnim = GetComponentInChildren<Animator>();
+        box = GetComponent<BoxCollider>();
     }
     // Stun has player object, stun time in seconds, trap itself
     // player has normal y velocity but is stopped in all other velocities and cannot move controls
@@ -51,6 +54,7 @@ public class Banana : MonoBehaviour {
             thisAnim.SetTrigger("Collide");
             anim.SetFloat("StunAnimSpeed", stunAnimSpeed);
             anim.Play("FaceplantStart", 0);
+            box.enabled = false;
             audioSource.PlayOneShot(clip);
         }
     }

--- a/Assets/Scripts/Traps/LogRoller.cs
+++ b/Assets/Scripts/Traps/LogRoller.cs
@@ -70,16 +70,16 @@ public class LogRoller : MonoBehaviour
                     switch (face)
                     {
                         case 1:
-                            logProjectile.transform.position = transform.position + new Vector3(-0.5f, 0.5f, 0);
+                            logProjectile.transform.position = transform.position + new Vector3(-0.5f, 0.4f, 0);
                             break;
                         case 2:
-                            logProjectile.transform.position = transform.position + new Vector3(0, 0.5f, -0.5f);
+                            logProjectile.transform.position = transform.position + new Vector3(0, 0.4f, -0.5f);
                             break;
                         case 3:
-                            logProjectile.transform.position = transform.position + new Vector3(0.5f, 0.5f, 0);
+                            logProjectile.transform.position = transform.position + new Vector3(0.5f, 0.4f, 0);
                             break;
                         case 4:
-                            logProjectile.transform.position = transform.position + new Vector3(0, 0.5f, 0.5f);
+                            logProjectile.transform.position = transform.position + new Vector3(0, 0.4f, 0.5f);
                             break;
                     }
                     logProjectile.transform.rotation = projectileRotation;

--- a/Assets/Scripts/Traps/Sap.cs
+++ b/Assets/Scripts/Traps/Sap.cs
@@ -81,9 +81,9 @@ public class Sap : MonoBehaviour {
             hit = true;
             player = other.gameObject;
             //Player animation goes to idle properly in sap.
+            anim = player.GetComponent<Animator>();
             if (player.GetComponent<PlayerOneMovement>().GetInputAxis() != 0)
             {
-                anim = player.GetComponent<PlayerOneMovement>().GetAnim();
                 if (player.GetComponent<PlayerOneMovement>().IsCrouched() == false && player.GetComponent<PlayerOneMovement>().IsStunned() == false && player.GetComponentInChildren<PlayerGrounded>().IsGrounded() == true)
                 {
                     anim.Play("Trudging", 0);


### PR DESCRIPTION
Slow and stun spell take longer to die. Didn't touch lightning, didn't want to cause merge conflicts with other pr.

Fix banana animations and all stun animations after getting hit with petrify.

Log roller shoots to the left properly and can be placed against a left wall now. It's hitbox has also been fixed to match its position.

Can jump off logs.

Sap get animator moved to a better place to stop null reference errors from it sometimes.

Banana turns off its collider after it is hit so it cannot trigger multiple times anymore.

Can walljump off crossbows and log rollers kinda now.

Delete Branch.