### PR TITLE
Buttons wrap around! & the L/R is slightly better,  + button sfx

### DIFF
--- a/Assets/Prefabs/Players and Cameras/Player 2.prefab
+++ b/Assets/Prefabs/Players and Cameras/Player 2.prefab
@@ -146,6 +146,7 @@ GameObject:
   - component: {fileID: 114220156261559540}
   - component: {fileID: 114871698429783546}
   - component: {fileID: 82713190498109326}
+  - component: {fileID: 114615252475970790}
   m_Layer: 0
   m_Name: Player 2
   m_TagString: Untagged
@@ -1777,6 +1778,17 @@ MonoBehaviour:
   trapPlacementBad: {fileID: 8300000, guid: 146332e6c2633ee4bbced98f867e9780, type: 3}
   queueSize: 7
   InputEnabled: 1
+--- !u!114 &114615252475970790
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1134238031081466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 781e602d8d46168409d59eecbe2b4a6c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114871698429783546
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Traps/ArrowTrap.prefab
+++ b/Assets/Prefabs/Traps/ArrowTrap.prefab
@@ -165,6 +165,7 @@ GameObject:
   - component: {fileID: 65457368768333654}
   - component: {fileID: 114173747208991380}
   - component: {fileID: 114003431253313008}
+  - component: {fileID: 114473459054956974}
   m_Layer: 0
   m_Name: ArrowTrap
   m_TagString: TrapHitbox
@@ -1614,6 +1615,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   nearbyTrap: 0
+--- !u!114 &114473459054956974
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1174657169313092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82acfb96bca68534e91d65c516482dfb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prePlaced: 0
+  faceNumber: 0
 --- !u!114 &114623097984117454
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Traps/BananaTrap.prefab
+++ b/Assets/Prefabs/Traps/BananaTrap.prefab
@@ -117,6 +117,7 @@ GameObject:
   - component: {fileID: 114426541480001402}
   - component: {fileID: 82968214060517958}
   - component: {fileID: 114553591053491990}
+  - component: {fileID: 114261852955086564}
   m_Layer: 0
   m_Name: BananaTrap
   m_TagString: Trap
@@ -1205,6 +1206,19 @@ MonoBehaviour:
   stunDuration: 2
   stunAnimSpeed: 1.1
   clip: {fileID: 8300000, guid: b499b720768ccc546b4a4062fa6200a7, type: 3}
+--- !u!114 &114261852955086564
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1156793421700370}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82acfb96bca68534e91d65c516482dfb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prePlaced: 0
+  faceNumber: 0
 --- !u!114 &114426541480001402
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Traps/LogRollerTrap.prefab
+++ b/Assets/Prefabs/Traps/LogRollerTrap.prefab
@@ -92,6 +92,7 @@ GameObject:
   - component: {fileID: 114893840394271494}
   - component: {fileID: 65076818654562268}
   - component: {fileID: 114105927209140518}
+  - component: {fileID: 114639867110281282}
   - component: {fileID: 114832420465715662}
   m_Layer: 0
   m_Name: LogRollerTrap
@@ -381,6 +382,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   nearbyTrap: 0
+--- !u!114 &114639867110281282
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1558432758084030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82acfb96bca68534e91d65c516482dfb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prePlaced: 0
+  faceNumber: 0
 --- !u!114 &114741705916860678
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Traps/SapTrap.prefab
+++ b/Assets/Prefabs/Traps/SapTrap.prefab
@@ -23,6 +23,7 @@ GameObject:
   - component: {fileID: 114603356562152718}
   - component: {fileID: 114833543942367270}
   - component: {fileID: 114453944344841684}
+  - component: {fileID: 114091553341782474}
   m_Layer: 0
   m_Name: SapTrap
   m_TagString: Trap
@@ -474,6 +475,19 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.3007248, y: 0.84204376, z: 0.39555025}
   m_Center: {x: -0.0009895324, y: -0.38098264, z: -0.009426355}
+--- !u!114 &114091553341782474
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1030923523706756}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82acfb96bca68534e91d65c516482dfb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prePlaced: 0
+  faceNumber: 0
 --- !u!114 &114453944344841684
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Traps/SpikeTrap.prefab
+++ b/Assets/Prefabs/Traps/SpikeTrap.prefab
@@ -196,6 +196,7 @@ GameObject:
   - component: {fileID: 136305195678973362}
   - component: {fileID: 82143525159479354}
   - component: {fileID: 114587062917528148}
+  - component: {fileID: 114917912283046884}
   m_Layer: 0
   m_Name: SpikeTrap
   m_TagString: Trap
@@ -779,6 +780,19 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+--- !u!114 &114917912283046884
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1781992477154930}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82acfb96bca68534e91d65c516482dfb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prePlaced: 0
+  faceNumber: 0
 --- !u!136 &136305195678973362
 CapsuleCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/UI/Canvas.prefab
+++ b/Assets/Prefabs/UI/Canvas.prefab
@@ -56,9 +56,7 @@ GameObject:
   - component: {fileID: 222807725281546402}
   - component: {fileID: 114867846818879346}
   - component: {fileID: 114598632826672602}
-  - component: {fileID: 82753511333846434}
   - component: {fileID: 114029162224760230}
-  - component: {fileID: 114737260551118388}
   m_Layer: 5
   m_Name: MenuButton
   m_TagString: Untagged
@@ -213,9 +211,7 @@ GameObject:
   - component: {fileID: 222923781926200632}
   - component: {fileID: 114941753935177412}
   - component: {fileID: 114375043952648214}
-  - component: {fileID: 82681677491176578}
   - component: {fileID: 114750004870101450}
-  - component: {fileID: 114519484602640240}
   m_Layer: 5
   m_Name: CharacterSelect
   m_TagString: Untagged
@@ -368,9 +364,7 @@ GameObject:
   - component: {fileID: 222298945735219922}
   - component: {fileID: 114481875212040844}
   - component: {fileID: 114582199479641044}
-  - component: {fileID: 82989244236944478}
   - component: {fileID: 114088070540639732}
-  - component: {fileID: 114045764208598956}
   m_Layer: 5
   m_Name: QuitButton
   m_TagString: Untagged
@@ -389,9 +383,7 @@ GameObject:
   - component: {fileID: 222047452771999378}
   - component: {fileID: 114424209296161108}
   - component: {fileID: 114165139153475708}
-  - component: {fileID: 82556723917319134}
   - component: {fileID: 114518233054957986}
-  - component: {fileID: 114313411723353788}
   m_Layer: 5
   m_Name: QuitButton
   m_TagString: Untagged
@@ -494,9 +486,7 @@ GameObject:
   - component: {fileID: 222830400596828648}
   - component: {fileID: 114188149438323000}
   - component: {fileID: 114288210665832730}
-  - component: {fileID: 82006336840751450}
   - component: {fileID: 114354668164926570}
-  - component: {fileID: 114329236042075336}
   m_Layer: 5
   m_Name: ResumeButton
   m_TagString: Untagged
@@ -566,9 +556,7 @@ GameObject:
   - component: {fileID: 222693528034790514}
   - component: {fileID: 114698183050738404}
   - component: {fileID: 114566155646271128}
-  - component: {fileID: 82460972647057432}
   - component: {fileID: 114457924785009408}
-  - component: {fileID: 114128406695603938}
   m_Layer: 5
   m_Name: RestartButton
   m_TagString: Untagged
@@ -792,9 +780,7 @@ GameObject:
   - component: {fileID: 222971572281094266}
   - component: {fileID: 114933143876282692}
   - component: {fileID: 114451648810339536}
-  - component: {fileID: 82895125763477552}
   - component: {fileID: 114166730416997624}
-  - component: {fileID: 114429752632936306}
   m_Layer: 5
   m_Name: MenuButton
   m_TagString: Untagged
@@ -933,9 +919,7 @@ GameObject:
   - component: {fileID: 222774767011875302}
   - component: {fileID: 114093429031358660}
   - component: {fileID: 114568986969309844}
-  - component: {fileID: 82700604281211804}
   - component: {fileID: 114157601995068408}
-  - component: {fileID: 114301829150665458}
   m_Layer: 5
   m_Name: ControlsButton
   m_TagString: Untagged
@@ -1092,9 +1076,7 @@ GameObject:
   - component: {fileID: 222242762514135792}
   - component: {fileID: 114820225972792002}
   - component: {fileID: 114200225477510150}
-  - component: {fileID: 82999333671785792}
   - component: {fileID: 114288039579541958}
-  - component: {fileID: 114624170559984128}
   m_Layer: 5
   m_Name: RestartButton
   m_TagString: Untagged
@@ -1102,101 +1084,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!82 &82006336840751450
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1542763188749338}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!82 &82007094550596446
 AudioSource:
   m_ObjectHideFlags: 1
@@ -1205,7 +1092,8 @@ AudioSource:
   m_GameObject: {fileID: 1803855440749550}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: 243714267952395700, guid: 8906dfadacdf5064080101660d028db8,
+    type: 2}
   m_audioClip: {fileID: 8300000, guid: 54ed9b080cd7f7849bf2220c1da7a564, type: 3}
   m_PlayOnAwake: 0
   m_Volume: 0.3
@@ -1300,770 +1188,11 @@ AudioSource:
   m_GameObject: {fileID: 1488436579819910}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: 243714267952395700, guid: 8906dfadacdf5064080101660d028db8,
+    type: 2}
   m_audioClip: {fileID: 8300000, guid: 54ed9b080cd7f7849bf2220c1da7a564, type: 3}
   m_PlayOnAwake: 0
   m_Volume: 0.3
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!82 &82460972647057432
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1590289651490990}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!82 &82556723917319134
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1487615652850902}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!82 &82681677491176578
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1282200965275460}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!82 &82700604281211804
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1834097967884820}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!82 &82753511333846434
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1033864121334520}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!82 &82895125763477552
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776386227033518}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!82 &82989244236944478
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1479127174915116}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!82 &82999333671785792
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1990415221541824}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -2294,8 +1423,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114737260551118388}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2311,8 +1440,25 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114737260551118388}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2328,25 +1474,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114737260551118388}
-          m_MethodName: ClickSound
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
-      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
-        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 114737260551118388}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2359,20 +1488,6 @@ MonoBehaviour:
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   delegates: []
---- !u!114 &114045764208598956
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1479127174915116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 82989244236944478}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 13c4d5f98250a4914aef9392adce2b8c, type: 3}
 --- !u!114 &114078629383218826
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2470,8 +1585,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114045764208598956}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2487,8 +1602,25 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114045764208598956}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2504,25 +1636,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114045764208598956}
-          m_MethodName: ClickSound
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
-      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
-        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 114045764208598956}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2675,20 +1790,6 @@ MonoBehaviour:
   - {fileID: 0}
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &114128406695603938
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1590289651490990}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 82460972647057432}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 0}
 --- !u!114 &114128878067443200
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2934,8 +2035,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114301829150665458}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2951,8 +2052,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114301829150665458}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2964,12 +2065,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
+  - eventID: 9
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114301829150665458}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2985,8 +2086,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114301829150665458}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3067,8 +2168,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114429752632936306}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3084,8 +2185,25 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114429752632936306}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3101,25 +2219,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114429752632936306}
-          m_MethodName: ClickSound
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
-      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
-        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 114429752632936306}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3593,8 +2694,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114624170559984128}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3606,12 +2707,46 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
+  - eventID: 4
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114624170559984128}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 15
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3676,48 +2811,6 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
---- !u!114 &114301829150665458
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1834097967884820}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 82700604281211804}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 13c4d5f98250a4914aef9392adce2b8c, type: 3}
---- !u!114 &114313411723353788
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1487615652850902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 82556723917319134}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 13c4d5f98250a4914aef9392adce2b8c, type: 3}
---- !u!114 &114329236042075336
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1542763188749338}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 82006336840751450}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 0}
 --- !u!114 &114354668164926570
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -3734,8 +2827,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114329236042075336}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3747,12 +2840,46 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
+  - eventID: 4
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114329236042075336}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 15
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -4347,20 +3474,6 @@ MonoBehaviour:
   - {fileID: 0}
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &114429752632936306
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776386227033518}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 82895125763477552}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 13c4d5f98250a4914aef9392adce2b8c, type: 3}
 --- !u!114 &114432546601970202
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -4542,8 +3655,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114128406695603938}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -4555,12 +3668,46 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
+  - eventID: 4
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114128406695603938}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 15
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -4810,8 +3957,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114313411723353788}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -4827,8 +3974,25 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114313411723353788}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -4844,25 +4008,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114313411723353788}
-          m_MethodName: ClickSound
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
-      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
-        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 114313411723353788}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -4875,20 +4022,6 @@ MonoBehaviour:
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   delegates: []
---- !u!114 &114519484602640240
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1282200965275460}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 82681677491176578}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 13c4d5f98250a4914aef9392adce2b8c, type: 3}
 --- !u!114 &114566155646271128
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -5463,20 +4596,6 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
---- !u!114 &114624170559984128
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1990415221541824}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 82999333671785792}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 0}
 --- !u!114 &114644478784002614
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -6365,20 +5484,6 @@ MonoBehaviour:
   - {fileID: 0}
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &114737260551118388
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1033864121334520}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 82753511333846434}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 13c4d5f98250a4914aef9392adce2b8c, type: 3}
 --- !u!114 &114750004870101450
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -6395,8 +5500,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114519484602640240}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -6412,8 +5517,25 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114519484602640240}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -6429,25 +5551,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114519484602640240}
-          m_MethodName: ClickSound
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
-      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
-        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 114519484602640240}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 0}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}

--- a/Assets/Scenes/Credits.unity
+++ b/Assets/Scenes/Credits.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -122,6 +122,9 @@ GameObject:
   m_Component:
   - component: {fileID: 115178478}
   - component: {fileID: 115178479}
+  - component: {fileID: 115178481}
+  - component: {fileID: 115178480}
+  - component: {fileID: 115178482}
   m_Layer: 0
   m_Name: MenuController
   m_TagString: Untagged
@@ -160,6 +163,129 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   menuButton: {fileID: 1372187430}
   es: {fileID: 1578249988}
+--- !u!114 &115178480
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 115178477}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hoverSFX: {fileID: 8300000, guid: f1669da3b6a04e24a954dc2b004f3151, type: 3}
+  selectSFX: {fileID: 8300000, guid: 7ed941244518d9a46ad4fe68b746beba, type: 3}
+--- !u!82 &115178481
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 115178477}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!114 &115178482
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 115178477}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b5c56dae0724b42b3ba0df1d8670482d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  loadImg: {fileID: 1040137383}
+  fadeAnim: {fileID: 1728052038}
+  logoFadeSpeed: 0.0505
+  loadTime: 1
 --- !u!1 &158401943
 GameObject:
   m_ObjectHideFlags: 0
@@ -473,6 +599,8 @@ RectTransform:
   m_Children:
   - {fileID: 1372187431}
   - {fileID: 158401944}
+  - {fileID: 1728052042}
+  - {fileID: 1040137381}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1114,6 +1242,75 @@ CanvasRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1017572684}
   m_CullTransparentMesh: 0
+--- !u!1 &1040137380
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1040137381}
+  - component: {fileID: 1040137382}
+  - component: {fileID: 1040137383}
+  m_Layer: 0
+  m_Name: LoadImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1040137381
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1040137380}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5557092, y: 0.5557092, z: 0.5557092}
+  m_Children: []
+  m_Father: {fileID: 203290745}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 700, y: 434.81}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1040137382
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1040137380}
+  m_CullTransparentMesh: 0
+--- !u!114 &1040137383
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1040137380}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: cee0f4aebdef8de48980f22bd751ec44, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
 --- !u!1 &1106519916
 GameObject:
   m_ObjectHideFlags: 0
@@ -1348,8 +1545,6 @@ GameObject:
   - component: {fileID: 1372187434}
   - component: {fileID: 1372187433}
   - component: {fileID: 1372187432}
-  - component: {fileID: 1372187435}
-  - component: {fileID: 1372187436}
   - component: {fileID: 1372187437}
   m_Layer: 0
   m_Name: Button
@@ -1463,115 +1658,6 @@ CanvasRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1372187430}
   m_CullTransparentMesh: 0
---- !u!114 &1372187435
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1372187430}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 1372187436}
-  hoverFx: {fileID: 0}
-  clickFx: {fileID: 8300000, guid: 13c4d5f98250a4914aef9392adce2b8c, type: 3}
---- !u!82 &1372187436
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1372187430}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!114 &1372187437
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1584,12 +1670,46 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Delegates:
+  - eventID: 0
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 115178480}
+          m_MethodName: Hover
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   - eventID: 4
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1372187435}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 115178480}
+          m_MethodName: Press
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 115178480}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1605,8 +1725,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1372187435}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 115178480}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1758,6 +1878,106 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1728052037
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1728052042}
+  - component: {fileID: 1728052041}
+  - component: {fileID: 1728052040}
+  - component: {fileID: 1728052038}
+  - component: {fileID: 1728052039}
+  m_Layer: 0
+  m_Name: LoadBlack
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!95 &1728052038
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1728052037}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 7c2cda4da6f074a698a7d218320adc63, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!225 &1728052039
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1728052037}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 0
+  m_BlocksRaycasts: 0
+  m_IgnoreParentGroups: 0
+--- !u!114 &1728052040
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1728052037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1728052041
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1728052037}
+  m_CullTransparentMesh: 0
+--- !u!224 &1728052042
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1728052037}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5557092, y: 0.5557092, z: 0.5557092}
+  m_Children: []
+  m_Father: {fileID: 203290745}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 853.2742, y: 479.70142}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1867468230
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Credits.unity
+++ b/Assets/Scenes/Credits.unity
@@ -125,6 +125,7 @@ GameObject:
   - component: {fileID: 115178481}
   - component: {fileID: 115178480}
   - component: {fileID: 115178482}
+  - component: {fileID: 115178483}
   m_Layer: 0
   m_Name: MenuController
   m_TagString: Untagged
@@ -286,6 +287,101 @@ MonoBehaviour:
   fadeAnim: {fileID: 1728052038}
   logoFadeSpeed: 0.0505
   loadTime: 1
+--- !u!82 &115178483
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 115178477}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 8300000, guid: 4af8a20958b197849a3f61900da1a4f0, type: 3}
+  m_PlayOnAwake: 1
+  m_Volume: 0.5
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &158401943
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -223,8 +223,6 @@ GameObject:
   - component: {fileID: 74656713}
   - component: {fileID: 74656712}
   - component: {fileID: 74656711}
-  - component: {fileID: 74656715}
-  - component: {fileID: 74656714}
   - component: {fileID: 74656716}
   m_Layer: 0
   m_Name: Button (1)
@@ -338,115 +336,6 @@ CanvasRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 74656709}
   m_CullTransparentMesh: 0
---- !u!114 &74656714
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 74656709}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 74656715}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 4f34767fffafc4b19be09973ceb1c926, type: 3}
---- !u!82 &74656715
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 74656709}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!114 &74656716
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -463,8 +352,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 74656714}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -476,12 +365,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 2
+  - eventID: 4
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 74656714}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -493,12 +382,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
+  - eventID: 9
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 74656714}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -514,8 +403,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 74656714}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1079,8 +968,6 @@ GameObject:
   - component: {fileID: 338748600}
   - component: {fileID: 338748599}
   - component: {fileID: 338748598}
-  - component: {fileID: 338748597}
-  - component: {fileID: 338748596}
   - component: {fileID: 338748595}
   m_Layer: 0
   m_Name: Button (2)
@@ -1124,8 +1011,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 338748596}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1137,12 +1024,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 2
+  - eventID: 4
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 338748596}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1154,12 +1041,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
+  - eventID: 9
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 338748596}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1175,8 +1062,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 338748596}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1189,115 +1076,6 @@ MonoBehaviour:
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   delegates: []
---- !u!114 &338748596
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 338748593}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 338748597}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 4f34767fffafc4b19be09973ceb1c926, type: 3}
---- !u!82 &338748597
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 338748593}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!114 &338748598
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1395,8 +1173,6 @@ GameObject:
   - component: {fileID: 543653431}
   - component: {fileID: 543653430}
   - component: {fileID: 543653429}
-  - component: {fileID: 543653428}
-  - component: {fileID: 543653427}
   - component: {fileID: 543653426}
   m_Layer: 0
   m_Name: Button (3)
@@ -1440,8 +1216,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 543653427}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1453,12 +1229,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 2
+  - eventID: 4
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 543653427}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1470,12 +1246,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
+  - eventID: 9
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 543653427}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1491,8 +1267,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 543653427}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1505,115 +1281,6 @@ MonoBehaviour:
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   delegates: []
---- !u!114 &543653427
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 543653424}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 543653428}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 4f34767fffafc4b19be09973ceb1c926, type: 3}
---- !u!82 &543653428
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 543653424}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!114 &543653429
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1963,7 +1630,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4152752662534782, guid: 76fcf7653de253e4aa606d9254deed80, type: 2}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 76fcf7653de253e4aa606d9254deed80, type: 2}
@@ -2048,8 +1715,6 @@ GameObject:
   - component: {fileID: 784251073}
   - component: {fileID: 784251072}
   - component: {fileID: 784251071}
-  - component: {fileID: 784251076}
-  - component: {fileID: 784251075}
   - component: {fileID: 784251074}
   m_Layer: 0
   m_Name: Button
@@ -2179,8 +1844,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 784251075}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2192,12 +1857,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 2
+  - eventID: 4
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 784251075}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2209,12 +1874,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
+  - eventID: 9
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 784251075}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2230,8 +1895,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 784251075}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2244,115 +1909,6 @@ MonoBehaviour:
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   delegates: []
---- !u!114 &784251075
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 784251069}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 784251076}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 13c4d5f98250a4914aef9392adce2b8c, type: 3}
---- !u!82 &784251076
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 784251069}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!1 &803056681
 GameObject:
   m_ObjectHideFlags: 0
@@ -2633,7 +2189,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &816572605
 GameObject:
@@ -2646,6 +2202,8 @@ GameObject:
   - component: {fileID: 816572606}
   - component: {fileID: 816572608}
   - component: {fileID: 816572609}
+  - component: {fileID: 816572611}
+  - component: {fileID: 816572610}
   m_Layer: 0
   m_Name: MenuController
   m_TagString: Untagged
@@ -2683,7 +2241,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &816572608
 MonoBehaviour:
@@ -2712,6 +2270,114 @@ MonoBehaviour:
   fadeAnim: {fileID: 1752076519}
   logoFadeSpeed: 0.0505
   loadTime: 1
+--- !u!114 &816572610
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 816572605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hoverSFX: {fileID: 8300000, guid: f1669da3b6a04e24a954dc2b004f3151, type: 3}
+  selectSFX: {fileID: 8300000, guid: 7ed941244518d9a46ad4fe68b746beba, type: 3}
+--- !u!82 &816572611
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 816572605}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &1241446601
 GameObject:
   m_ObjectHideFlags: 0
@@ -2789,8 +2455,6 @@ GameObject:
   - component: {fileID: 1340628006}
   - component: {fileID: 1340628005}
   - component: {fileID: 1340628004}
-  - component: {fileID: 1340628009}
-  - component: {fileID: 1340628008}
   - component: {fileID: 1340628007}
   m_Layer: 0
   m_Name: NoButton
@@ -2920,8 +2584,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1340628008}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2933,12 +2597,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 2
+  - eventID: 4
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1340628008}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2950,12 +2614,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
+  - eventID: 9
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1340628008}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2971,8 +2635,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1340628008}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -2985,115 +2649,6 @@ MonoBehaviour:
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   delegates: []
---- !u!114 &1340628008
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1340628002}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 1340628009}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 13c4d5f98250a4914aef9392adce2b8c, type: 3}
---- !u!82 &1340628009
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1340628002}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!1 &1552851351
 GameObject:
   m_ObjectHideFlags: 0
@@ -3182,8 +2737,6 @@ GameObject:
   - component: {fileID: 1578665437}
   - component: {fileID: 1578665436}
   - component: {fileID: 1578665435}
-  - component: {fileID: 1578665440}
-  - component: {fileID: 1578665439}
   - component: {fileID: 1578665438}
   m_Layer: 0
   m_Name: YesButton
@@ -3313,8 +2866,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1578665439}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3326,12 +2879,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 2
+  - eventID: 4
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1578665439}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3343,12 +2896,12 @@ MonoBehaviour:
           m_CallState: 2
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  - eventID: 10
+  - eventID: 9
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1578665439}
-          m_MethodName: HoverSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Hover
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3364,8 +2917,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1578665439}
-          m_MethodName: ClickSound
+        - m_Target: {fileID: 816572610}
+          m_MethodName: Press
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3378,115 +2931,6 @@ MonoBehaviour:
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   delegates: []
---- !u!114 &1578665439
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1578665433}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myFx: {fileID: 1578665440}
-  hoverFx: {fileID: 8300000, guid: a59ce4c82c4644d34b9d2dd43e8851e9, type: 3}
-  clickFx: {fileID: 8300000, guid: 13c4d5f98250a4914aef9392adce2b8c, type: 3}
---- !u!82 &1578665440
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1578665433}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!1 &1730473637
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Tower1.unity
+++ b/Assets/Scenes/Tower1.unity
@@ -832,11 +832,11 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 29.999996
+      value: 29.999992
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.57405
+      value: -80.62278
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalRotation.x
@@ -5124,6 +5124,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   GameIsPaused: 0
+  popupSFX: {fileID: 8300000, guid: 4eb4ad40362d54b499c11f208d3a91de, type: 3}
   pauseMenuUI: {fileID: 577860162}
   pauseButtons:
   - {fileID: 31970729}
@@ -7619,126 +7620,6 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 114088070540639732, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.size
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 114029162224760230, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.size
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 114157601995068408, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.size
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 114288039579541958, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 114354668164926570, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 114457924785009408, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 114750004870101450, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.size
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 114166730416997624, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.size
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 114518233054957986, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.size
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 114088070540639732, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114088070540639732, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114029162224760230, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114029162224760230, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114157601995068408, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114157601995068408, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114288039579541958, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114354668164926570, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114457924785009408, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114750004870101450, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114750004870101450, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114166730416997624, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114166730416997624, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114518233054957986, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114518233054957986, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 224152661617058486, guid: c130ae0761b27334089036b39347c937,
         type: 2}
       propertyPath: m_LocalPosition.x
@@ -7829,26 +7710,206 @@ Prefab:
       propertyPath: m_Pivot.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 114288039579541958, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114288039579541958, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114288039579541958, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114288039579541958, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114157601995068408, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114157601995068408, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114157601995068408, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114157601995068408, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114166730416997624, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114166730416997624, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114166730416997624, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114166730416997624, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
     - target: {fileID: 114451648810339536, guid: c130ae0761b27334089036b39347c937,
         type: 2}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1888857412}
-    - target: {fileID: 114165139153475708, guid: c130ae0761b27334089036b39347c937,
+    - target: {fileID: 114457924785009408, guid: c130ae0761b27334089036b39347c937,
         type: 2}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 1016487809}
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114457924785009408, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114457924785009408, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114457924785009408, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
     - target: {fileID: 114566155646271128, guid: c130ae0761b27334089036b39347c937,
         type: 2}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1888857412}
+    - target: {fileID: 114354668164926570, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114354668164926570, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114354668164926570, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114354668164926570, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114518233054957986, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114518233054957986, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114518233054957986, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114518233054957986, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114165139153475708, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1016487809}
+    - target: {fileID: 114088070540639732, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114088070540639732, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114088070540639732, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114088070540639732, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114750004870101450, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114750004870101450, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114750004870101450, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114750004870101450, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
     - target: {fileID: 114375043952648214, guid: c130ae0761b27334089036b39347c937,
         type: 2}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1888857412}
+    - target: {fileID: 114029162224760230, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114029162224760230, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114029162224760230, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[2].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
+    - target: {fileID: 114029162224760230, guid: c130ae0761b27334089036b39347c937,
+        type: 2}
+      propertyPath: m_Delegates.Array.data[3].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1888857414}
     - target: {fileID: 114288210665832730, guid: c130ae0761b27334089036b39347c937,
         type: 2}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -7884,18 +7945,6 @@ Prefab:
       propertyPath: m_isInputParsingRequired
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 82007094550596446, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: OutputAudioMixerGroup
-      value: 
-      objectReference: {fileID: 243714267952395700, guid: 8906dfadacdf5064080101660d028db8,
-        type: 2}
-    - target: {fileID: 82187409698111396, guid: c130ae0761b27334089036b39347c937,
-        type: 2}
-      propertyPath: OutputAudioMixerGroup
-      value: 
-      objectReference: {fileID: 243714267952395700, guid: 8906dfadacdf5064080101660d028db8,
-        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c130ae0761b27334089036b39347c937, type: 2}
   m_IsPrefabAsset: 0
@@ -9862,6 +9911,7 @@ GameObject:
   - component: {fileID: 1888857410}
   - component: {fileID: 1888857412}
   - component: {fileID: 1888857413}
+  - component: {fileID: 1888857414}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -9913,7 +9963,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: d5ce3ddc1fb044b4bbc27caf3fbebaed, type: 3}
   m_PlayOnAwake: 1
-  m_Volume: 0.01
+  m_Volume: 0.883
   m_Pitch: 1
   Loop: 1
   Mute: 0
@@ -10056,6 +10106,19 @@ MonoBehaviour:
   fadeAnim: {fileID: 2004897668}
   logoFadeSpeed: 0.0505
   loadTime: 1
+--- !u!114 &1888857414
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1888857407}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db222b8d200834c62a72cc1872333ade, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hoverSFX: {fileID: 8300000, guid: f1669da3b6a04e24a954dc2b004f3151, type: 3}
+  selectSFX: {fileID: 8300000, guid: 7ed941244518d9a46ad4fe68b746beba, type: 3}
 --- !u!4 &1917265628 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4063479449427360, guid: c95eca2a304e62c4abe3cc7a52590fd5,
@@ -11088,11 +11151,11 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 29.999996
+      value: 29.999992
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.57405
+      value: -80.62278
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalRotation.x

--- a/Assets/Scenes/Tower1.unity
+++ b/Assets/Scenes/Tower1.unity
@@ -832,11 +832,11 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 29.999998
+      value: 29.999996
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.57439
+      value: -80.57405
       objectReference: {fileID: 0}
     - target: {fileID: 4758679635353836, guid: cfd428a7fbb7c3042a80eb1763f22607, type: 2}
       propertyPath: m_LocalRotation.x
@@ -3326,7 +3326,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4118745448429798, guid: 4177dabbb2b6dc24aa87ac8ef64cc13e, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 11
+      value: 8.928822
       objectReference: {fileID: 0}
     - target: {fileID: 4118745448429798, guid: 4177dabbb2b6dc24aa87ac8ef64cc13e, type: 2}
       propertyPath: m_LocalPosition.z
@@ -5274,7 +5274,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4743651345122740, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 11
+      value: 8.928822
       objectReference: {fileID: 0}
     - target: {fileID: 4743651345122740, guid: 415a8da459df20b4ba20fdbb2acbdc98, type: 2}
       propertyPath: m_LocalPosition.z
@@ -5829,7 +5829,7 @@ MonoBehaviour:
   m_SubmitButton: Nothing
   m_CancelButton: Cancel
   m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
+  m_RepeatDelay: 3
   m_ForceModuleActive: 0
 --- !u!114 &1160000097
 MonoBehaviour:
@@ -11088,11 +11088,11 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 29.999998
+      value: 29.999996
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -80.57439
+      value: -80.57405
       objectReference: {fileID: 0}
     - target: {fileID: 4940846812731354, guid: 295df6c694235764eac79c393ed826dc, type: 2}
       propertyPath: m_LocalRotation.x

--- a/Assets/Scenes/Tower1_Traps.unity
+++ b/Assets/Scenes/Tower1_Traps.unity
@@ -175,6 +175,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114091553341782474, guid: 14716dac1aa2c7a488003f7bba1968d3,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114091553341782474, guid: 14716dac1aa2c7a488003f7bba1968d3,
+        type: 2}
+      propertyPath: faceNumber
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 14716dac1aa2c7a488003f7bba1968d3, type: 2}
   m_IsPrefabAsset: 0
@@ -236,6 +246,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114091553341782474, guid: 14716dac1aa2c7a488003f7bba1968d3,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114091553341782474, guid: 14716dac1aa2c7a488003f7bba1968d3,
+        type: 2}
+      propertyPath: faceNumber
+      value: 4
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 14716dac1aa2c7a488003f7bba1968d3, type: 2}
   m_IsPrefabAsset: 0
@@ -293,6 +313,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114091553341782474, guid: 14716dac1aa2c7a488003f7bba1968d3,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114091553341782474, guid: 14716dac1aa2c7a488003f7bba1968d3,
+        type: 2}
+      propertyPath: faceNumber
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 14716dac1aa2c7a488003f7bba1968d3, type: 2}
   m_IsPrefabAsset: 0
@@ -347,6 +377,16 @@ Prefab:
         type: 2}
       propertyPath: Placed
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: faceNumber
+      value: 4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 978902421daf7ca4eb1ed6dc15ac1645, type: 2}
@@ -419,6 +459,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114473459054956974, guid: b34de131824cbe447931d0a2d1e0696b,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114473459054956974, guid: b34de131824cbe447931d0a2d1e0696b,
+        type: 2}
+      propertyPath: faceNumber
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b34de131824cbe447931d0a2d1e0696b, type: 2}
   m_IsPrefabAsset: 0
@@ -464,6 +514,16 @@ Prefab:
     - target: {fileID: 114165052816273324, guid: 978902421daf7ca4eb1ed6dc15ac1645,
         type: 2}
       propertyPath: Placed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: faceNumber
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -527,6 +587,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114091553341782474, guid: 14716dac1aa2c7a488003f7bba1968d3,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114091553341782474, guid: 14716dac1aa2c7a488003f7bba1968d3,
+        type: 2}
+      propertyPath: faceNumber
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 14716dac1aa2c7a488003f7bba1968d3, type: 2}
   m_IsPrefabAsset: 0
@@ -586,6 +656,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114261852955086564, guid: 7b86cd6111e958843812033b42c97d80,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114261852955086564, guid: 7b86cd6111e958843812033b42c97d80,
+        type: 2}
+      propertyPath: faceNumber
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7b86cd6111e958843812033b42c97d80, type: 2}
   m_IsPrefabAsset: 0
@@ -640,6 +720,16 @@ Prefab:
         type: 2}
       propertyPath: Placed
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: faceNumber
+      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 978902421daf7ca4eb1ed6dc15ac1645, type: 2}
@@ -716,6 +806,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114473459054956974, guid: b34de131824cbe447931d0a2d1e0696b,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114473459054956974, guid: b34de131824cbe447931d0a2d1e0696b,
+        type: 2}
+      propertyPath: faceNumber
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b34de131824cbe447931d0a2d1e0696b, type: 2}
   m_IsPrefabAsset: 0
@@ -791,6 +891,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114473459054956974, guid: b34de131824cbe447931d0a2d1e0696b,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114473459054956974, guid: b34de131824cbe447931d0a2d1e0696b,
+        type: 2}
+      propertyPath: faceNumber
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b34de131824cbe447931d0a2d1e0696b, type: 2}
   m_IsPrefabAsset: 0
@@ -842,6 +952,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: faceNumber
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 978902421daf7ca4eb1ed6dc15ac1645, type: 2}
   m_IsPrefabAsset: 0
@@ -892,6 +1012,16 @@ Prefab:
         type: 2}
       propertyPath: Placed
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114261852955086564, guid: 7b86cd6111e958843812033b42c97d80,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114261852955086564, guid: 7b86cd6111e958843812033b42c97d80,
+        type: 2}
+      propertyPath: faceNumber
+      value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7b86cd6111e958843812033b42c97d80, type: 2}
@@ -948,6 +1078,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: faceNumber
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 978902421daf7ca4eb1ed6dc15ac1645, type: 2}
   m_IsPrefabAsset: 0
@@ -998,6 +1138,16 @@ Prefab:
         type: 2}
       propertyPath: Placed
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114917912283046884, guid: 978902421daf7ca4eb1ed6dc15ac1645,
+        type: 2}
+      propertyPath: faceNumber
+      value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 978902421daf7ca4eb1ed6dc15ac1645, type: 2}
@@ -1060,6 +1210,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114091553341782474, guid: 14716dac1aa2c7a488003f7bba1968d3,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114091553341782474, guid: 14716dac1aa2c7a488003f7bba1968d3,
+        type: 2}
+      propertyPath: faceNumber
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 14716dac1aa2c7a488003f7bba1968d3, type: 2}
   m_IsPrefabAsset: 0
@@ -1109,6 +1269,16 @@ Prefab:
     - target: {fileID: 114828653977396230, guid: 7b86cd6111e958843812033b42c97d80,
         type: 2}
       propertyPath: Placed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114261852955086564, guid: 7b86cd6111e958843812033b42c97d80,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114261852955086564, guid: 7b86cd6111e958843812033b42c97d80,
+        type: 2}
+      propertyPath: faceNumber
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -1190,6 +1360,16 @@ Prefab:
       propertyPath: Placed
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114473459054956974, guid: b34de131824cbe447931d0a2d1e0696b,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114473459054956974, guid: b34de131824cbe447931d0a2d1e0696b,
+        type: 2}
+      propertyPath: faceNumber
+      value: 4
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b34de131824cbe447931d0a2d1e0696b, type: 2}
   m_IsPrefabAsset: 0
@@ -1259,6 +1439,16 @@ Prefab:
         type: 2}
       propertyPath: Placed
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114473459054956974, guid: b34de131824cbe447931d0a2d1e0696b,
+        type: 2}
+      propertyPath: prePlaced
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114473459054956974, guid: b34de131824cbe447931d0a2d1e0696b,
+        type: 2}
+      propertyPath: faceNumber
+      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b34de131824cbe447931d0a2d1e0696b, type: 2}

--- a/Assets/Scripts/Audio/buttonSFX.cs
+++ b/Assets/Scripts/Audio/buttonSFX.cs
@@ -1,21 +1,27 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
+[RequireComponent(typeof(AudioSource))]
 public class buttonSFX : MonoBehaviour {
 
 
-	public AudioSource myFx;
-	public AudioClip hoverFx;
-	public AudioClip clickFx;
+	private AudioSource audioSource;
+	[SerializeField] private AudioClip hoverSFX;
+    [SerializeField] private AudioClip selectSFX;
 
+    private void Start()
+    {
+        audioSource = GetComponent<AudioSource>();
+    }
 
-	public void HoverSound(){
-		myFx.PlayOneShot(hoverFx);
+    public void Hover(){
+		if(audioSource != null && hoverSFX != null) audioSource.PlayOneShot(hoverSFX);
 	}
 
-	public void ClickSound(){
-		myFx.PlayOneShot(clickFx);
+	public void Press(){
+        if (audioSource != null && selectSFX != null) audioSource.PlayOneShot(selectSFX);
 	}
 
 }

--- a/Assets/Scripts/CheckRenderers.cs
+++ b/Assets/Scripts/CheckRenderers.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CheckRenderers : MonoBehaviour {
+    [SerializeField] private bool prePlaced;
+    [SerializeField] private int faceNumber;
+
+    private int floor, face;
+    private CameraOneRotator bottomCam;
+    private CameraTwoRotator topCam;
+
+    private MeshRenderer[] mrs;
+    private SkinnedMeshRenderer[] smrs;
+
+    private bool on, prevOn;
+    private void Awake()
+    {
+        topCam = GameObject.Find("Player 2 Camera").GetComponent<CameraTwoRotator>();
+        bottomCam = GameObject.Find("Player 1").GetComponent<CameraOneRotator>();
+
+        mrs = GetComponentsInChildren<MeshRenderer>();
+        smrs = GetComponentsInChildren<SkinnedMeshRenderer>();
+    }
+
+    private void Start()
+    {
+        face = topCam.GetState();
+        floor = topCam.GetFloor();
+    }
+
+    private void Update()
+    {
+        bool topCamLooking, bottomCamLooking;
+
+        if(prePlaced)
+        {
+            topCamLooking = false;
+            bottomCamLooking = faceNumber == bottomCam.GetState() && 1 == bottomCam.GetFloor();
+        }
+        else
+        {
+            topCamLooking = face == topCam.GetState() && floor == topCam.GetFloor();
+            bottomCamLooking = face == bottomCam.GetState() && floor == bottomCam.GetFloor();
+        }
+
+        if (topCamLooking || bottomCamLooking)
+        {
+            foreach (MeshRenderer mr in mrs)
+            {
+                if (mr != null) mr.enabled = true;
+            }
+
+            foreach (SkinnedMeshRenderer smr in smrs)
+            {
+                if (smr != null) smr.enabled = true;
+            }
+        }
+        else
+        {
+            foreach (MeshRenderer mr in mrs)
+            {
+                if (mr != null) mr.enabled = false;
+            }
+
+            foreach (SkinnedMeshRenderer smr in smrs)
+            {
+                if (smr != null) smr.enabled = false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/CheckRenderers.cs.meta
+++ b/Assets/Scripts/CheckRenderers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82acfb96bca68534e91d65c516482dfb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/GenerateFaceFromText.cs
+++ b/Assets/Scripts/Editor/GenerateFaceFromText.cs
@@ -80,6 +80,7 @@ public class GenerateFaceFromText
                                 GameObject spawnedPlatform = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
                                 spawnedPlatform.transform.position = new Vector3(i * 2, lineNumber * -2, 0);
                                 spawnedPlatform.transform.eulerAngles = new Vector3(-90, 180, 0); // fix incorrect rotation on prefabs
+                                spawnedPlatform.isStatic = true;
 
                                 //store transform
                                 transformList.Add(spawnedPlatform.transform);
@@ -92,6 +93,7 @@ public class GenerateFaceFromText
                                 GameObject spawnedPlatform = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
                                 spawnedPlatform.transform.position = new Vector3(i * 2, lineNumber * -2, 0);
                                 spawnedPlatform.transform.eulerAngles = new Vector3(-90, 180, 0);
+                                spawnedPlatform.isStatic = true;
 
                                 //store transform
                                 transformList.Add(spawnedPlatform.transform);

--- a/Assets/Scripts/Players/CastSpell.cs
+++ b/Assets/Scripts/Players/CastSpell.cs
@@ -311,7 +311,7 @@ public class CastSpell : MonoBehaviour
                 spell = null;
 
                 ClearButton();
-
+                GetComponent<ChangeNav>().ResetNav();
                 DestroyTarget();
 
                 if (p2Controller)
@@ -729,6 +729,7 @@ public class CastSpell : MonoBehaviour
             if(cooldownTimePassed >= cooldownTime)
             {
                 button.interactable = true;
+                GetComponent<ChangeNav>().ResetNav();
 
                 if (eventSystem.currentSelectedGameObject == null && p2Controller)
                 {

--- a/Assets/Scripts/Players/PlaceTrap.cs
+++ b/Assets/Scripts/Players/PlaceTrap.cs
@@ -107,13 +107,13 @@ public class PlaceTrap : MonoBehaviour {
             queue[0].gameObject.GetComponent<Button>().Select();
         }
     }
-	
+    
 
 	void Update () {
         //Move ghost with cursor
         MoveGhost();
         //Get controller select
-        p2Controller = checkControllers.GetTopPlayerControllerState();
+        if(checkControllers != null) p2Controller = checkControllers.GetTopPlayerControllerState();
         if (p2Controller && !pause.GameIsPaused)
         {
             if (inputManager.GetButtonDown(InputCommand.TopPlayerSelect) && InputEnabled)
@@ -137,6 +137,8 @@ public class PlaceTrap : MonoBehaviour {
             ClearTrapQueue();
             CreateTrapQueue();
             if(p2Controller) eventSystem.SetSelectedGameObject(queue[0]);
+
+            GetComponent<ChangeNav>().ResetNav();
             cursorMove.MovingTraps = true;
             controllerCursor.transform.localPosition = new Vector3(-1, -1, 0);
         }
@@ -372,7 +374,10 @@ public class PlaceTrap : MonoBehaviour {
                     if (check != null) check.Placed = true;
                     previouslySelectedIndex = queueIndex;
 
+                    
                     ClearButton();
+                    GetComponent<ChangeNav>().ResetNav();
+
                     trap = null;
                     foreach (SpriteRenderer sr in placementSquares)
                     {
@@ -713,6 +718,8 @@ public class PlaceTrap : MonoBehaviour {
                 queue[i].GetComponent<Button>().interactable = false;
             }
         }
+
+        //GetComponent<ChangeNav>().ResetNav();
 
     }
 

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -426,6 +426,14 @@ public class PlayerOneMovement : MonoBehaviour {
             animator.SetBool("Crouched", crouching);
             animator.SetFloat("YVelocity", rb.velocity.y);
         }
+        else if(gameOver.GameOver)
+        {
+            movementVector = Vector3.zero;
+            move = false;
+            jumping = false;
+            crouching = false;
+
+        }
         
     }
 

--- a/Assets/Scripts/Traps/ProjectileShooter.cs
+++ b/Assets/Scripts/Traps/ProjectileShooter.cs
@@ -4,8 +4,8 @@ using UnityEngine;
 
 public class ProjectileShooter : MonoBehaviour {
     public int FaceNumberIfPrePlaced;
-    public int FaceNumber;
-    public int FloorNumber;
+    [HideInInspector] public int FaceNumber;
+    [HideInInspector] public int FloorNumber;
 
 
     public CameraTwoRotator cam2;

--- a/Assets/Scripts/Traps/ProjectileShooter.cs
+++ b/Assets/Scripts/Traps/ProjectileShooter.cs
@@ -113,7 +113,7 @@ public class ProjectileShooter : MonoBehaviour {
     {
         if (!gameOver.GameOver && ((FaceNumber == cam1.GetState() && FloorNumber == cam1.GetFloor()) || (FaceNumber == cam2.GetState() && FloorNumber == cam2.GetFloor())))
         {
-            col = projectile.GetComponent<BoxCollider>();
+            if (projectile != null) col = projectile.GetComponent<BoxCollider>();
             if (col != null) col.enabled = true;
             if (rb != null) rb.velocity = velocity;
         }

--- a/Assets/Scripts/UI/BeginGo.cs
+++ b/Assets/Scripts/UI/BeginGo.cs
@@ -100,5 +100,6 @@ public class BeginGo : MonoBehaviour {
 
         //Show
         ZoomCam.cullingMask |= 1 << LayerMask.NameToLayer("Trees1");
+        GameObject.Find("Player 2").GetComponent<ChangeNav>().ResetNav();
     }
 }

--- a/Assets/Scripts/UI/Buttons/ChangeNav.cs
+++ b/Assets/Scripts/UI/Buttons/ChangeNav.cs
@@ -103,7 +103,7 @@ public class ChangeNav : MonoBehaviour {
                 if(currentLastButton == null)
                 {
                     currentLastButton = cs.queue[s];
-                    Debug.Log(currentLastButton);
+
                     if(s > 0 && cs.queue[s - 1] != null)
                     {
                         currentSecondLastButton = cs.queue[s - 1];

--- a/Assets/Scripts/UI/Buttons/ChangeNav.cs
+++ b/Assets/Scripts/UI/Buttons/ChangeNav.cs
@@ -1,0 +1,135 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ChangeNav : MonoBehaviour {
+    private CastSpell cs;
+    private PlaceTrap pt;
+
+    private GameObject currentFirstButton;
+    private GameObject currentSecondButton;
+    private GameObject currentLastButton;
+    private GameObject currentSecondLastButton;
+
+	void Start ()
+    {
+        GameObject player = GameObject.Find("Player 2");
+        cs = player.GetComponent<CastSpell>();
+        pt = player.GetComponent<PlaceTrap>();
+    }
+	
+    public void ResetNav()
+    {
+        GetCurrentFirstButtons();
+        GetCurrentLastButtons();
+
+        //Debug.Log("\n" + currentFirstButton);
+        //Debug.Log("\n" + currentSecondButton);
+        //Debug.Log("\n" + currentSecondLastButton);
+        //Debug.Log("\n" + currentLastButton);
+
+        //Change navigation of first and last buttons to wrap around
+
+        if (currentFirstButton != null)
+        {
+            Navigation navFirst = currentFirstButton.GetComponent<Button>().navigation;
+            navFirst.mode = Navigation.Mode.Explicit;
+            if (currentLastButton != null) navFirst.selectOnLeft = currentLastButton.GetComponent<Button>();
+            if (currentSecondButton != null) navFirst.selectOnRight = currentSecondButton.GetComponent<Button>();
+            currentFirstButton.GetComponent<Button>().navigation = navFirst;
+        }
+
+        if (currentLastButton != null)
+        {
+            Navigation navLast = currentLastButton.GetComponent<Button>().navigation;
+            navLast.mode = Navigation.Mode.Explicit;
+            if (currentSecondLastButton != null) navLast.selectOnLeft = currentSecondLastButton.GetComponent<Button>();
+            if (currentFirstButton != null) navLast.selectOnRight = currentFirstButton.GetComponent<Button>();
+            currentLastButton.GetComponent<Button>().navigation = navLast;
+        }
+
+        //Reset to null
+        currentFirstButton = null;
+        currentSecondButton = null;
+        currentSecondLastButton = null;
+        currentLastButton = null;
+    }
+
+
+    private void GetCurrentFirstButtons()
+    {
+
+            foreach (GameObject t in pt.queue)
+            {
+                if (t != null && t.activeInHierarchy && t.GetComponent<Button>().interactable)
+                {
+                    if (currentFirstButton == null)
+                    {
+                        currentFirstButton = t;
+                    }
+                    else
+                    {
+                        currentSecondButton = t;
+                        return;
+                    }
+                }
+            }
+
+            for (int s = 0; s < cs.queue.Length; s++)
+            {
+                if (cs.queue[s] != null && cs.queue[s].activeInHierarchy && cs.queue[s].GetComponent<Button>().interactable)
+                {
+                    if (currentFirstButton == null)
+                    {
+                        currentFirstButton = cs.queue[s];
+                    }
+                    else
+                    {
+                        currentSecondButton = cs.queue[s];
+                        return;
+                    }
+                }
+            }
+        
+    }
+
+    private void GetCurrentLastButtons()
+    {
+        for (int s = cs.queue.Length - 1; s >= 0; s--)
+        {
+            if (cs.queue[s] != null && cs.queue[s].activeInHierarchy && cs.queue[s].GetComponent<Button>().interactable)
+            {
+                if(currentLastButton == null)
+                {
+                    currentLastButton = cs.queue[s];
+                    Debug.Log(currentLastButton);
+                    if(s > 0 && cs.queue[s - 1] != null)
+                    {
+                        currentSecondLastButton = cs.queue[s - 1];
+                        return;
+                    }
+                }
+            }
+        }
+
+        for(int t = pt.queue.Count - 1; t >= 0; t--)
+        {
+            if (pt.queue[t] != null && pt.queue[t].activeInHierarchy && pt.queue[t].GetComponent<Button>().interactable)
+            {
+                if(currentLastButton == null)
+                {
+                    currentLastButton = pt.queue[t];
+                    if(t > 0 && pt.queue[t - 1] != null)
+                    {
+                        currentSecondLastButton = pt.queue[t - 1];
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+
+
+}

--- a/Assets/Scripts/UI/Buttons/ChangeNav.cs.meta
+++ b/Assets/Scripts/UI/Buttons/ChangeNav.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 781e602d8d46168409d59eecbe2b4a6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Menus/CreditsMenu.cs
+++ b/Assets/Scripts/UI/Menus/CreditsMenu.cs
@@ -9,11 +9,14 @@ public class CreditsMenu : MonoBehaviour {
     [SerializeField] EventSystem es;
     
     private CheckControllers checkControllers;
+    private SceneTransition loader;
 
     private void Awake()
     {
         GameObject inputObj = GameObject.Find("InputManager");
         checkControllers = inputObj.GetComponent<CheckControllers>();
+
+        loader = GetComponent<SceneTransition>();
     }
 
     void Start ()
@@ -34,6 +37,6 @@ public class CreditsMenu : MonoBehaviour {
 
     public void OnClickMenu()
     {
-        SceneManager.LoadScene("Menu");
+        StartCoroutine(loader.LoadScene("Menu"));
     }
 }

--- a/Assets/Scripts/UI/Menus/GameOverMenu.cs
+++ b/Assets/Scripts/UI/Menus/GameOverMenu.cs
@@ -27,11 +27,18 @@ public class GameOverMenu : MonoBehaviour {
     private CheckControllers cc;
     private TextMeshProUGUI charSelectText;
     private SceneTransition loader;
+    private StandaloneInputModule inputModule;
 
     private void Start()
     {
+        //inputs
         cc = GameObject.Find("InputManager").GetComponent<CheckControllers>();
+        inputModule = es.GetComponent<StandaloneInputModule>();
+
+        //char select stuff - we disable the button if they're only playing with mouse and keyboard
         charSelectText = charSelectButton.GetComponentInChildren<TextMeshProUGUI>();
+
+        //players
         GameObject p1 = GameObject.Find("Player 1");
         player1 = p1.GetComponent<PlayerOneMovement>();
 
@@ -45,7 +52,11 @@ public class GameOverMenu : MonoBehaviour {
 
     public void Open(bool speccyWin)
     {
+        //Start fade
         Instantiate(fadePrefab);
+        StartCoroutine(FadeMusic(speccyWin));
+
+        //Disable inputs for players
         cs.InputEnabled = false;
         pt.InputEnabled = false;
         player1.InputEnabled = false;
@@ -53,6 +64,7 @@ public class GameOverMenu : MonoBehaviour {
         vines.Started = false;
         GameOver = true;
 
+        //Change game over text
         if (speccyWin)
         {
             text.text = "Bottom Player Wins!";
@@ -61,10 +73,12 @@ public class GameOverMenu : MonoBehaviour {
         {
             text.text = "Top Player Wins!";
         }
+        
+        //set input module
+        inputModule.submitButton = "Submit_Menu";
+        inputModule.repeatDelay = 0.5f;
 
-        StartCoroutine(FadeMusic(speccyWin));
-
-        es.GetComponent<StandaloneInputModule>().submitButton = "Submit_Menu";
+        //set character select button interactable or uninteractable based on whether they're using controllers
         if (cc != null && charSelectText != null)
         {
             if (!(cc.GetControllerOneState() || cc.GetControllerTwoState()))
@@ -84,12 +98,11 @@ public class GameOverMenu : MonoBehaviour {
     {
         if (cc.GetBottomPlayerControllerState() || cc.topPlayersController)
         {
-
             es.SetSelectedGameObject(restartButton);
-        }
-        
+        }    
     }
 
+    //Buttons
     public void onClickRetry()
     {
         StartCoroutine(loader.LoadScene("Tower1"));
@@ -118,16 +131,21 @@ public class GameOverMenu : MonoBehaviour {
         Application.Quit();
     }
 
+
+
+    //Music fade
     private IEnumerator FadeMusic(bool speccyWin)
     {
         float fadeTime = 2;
 
+        //fade out
         for(float t = 0; t < fadeTime; t += Time.deltaTime)
         {
             musicPlayer.volume = Mathf.Lerp(1, 0, t / fadeTime);
             yield return null;
         }
 
+        //set new clip
         if(speccyWin)
         {
             musicPlayer.clip = speccyWinMusic;
@@ -138,6 +156,7 @@ public class GameOverMenu : MonoBehaviour {
         }
         musicPlayer.Play();
 
+        //fade back in
         for (float t = 0; t < fadeTime; t += Time.deltaTime)
         {
             musicPlayer.volume = Mathf.Lerp(0, 1, t / fadeTime);

--- a/Assets/Scripts/UI/Menus/GameOverMenu.cs
+++ b/Assets/Scripts/UI/Menus/GameOverMenu.cs
@@ -26,6 +26,7 @@ public class GameOverMenu : MonoBehaviour {
     private CastSpell cs;
     private CheckControllers cc;
     private TextMeshProUGUI charSelectText;
+    private SceneTransition loader;
 
     private void Start()
     {
@@ -37,6 +38,9 @@ public class GameOverMenu : MonoBehaviour {
         GameObject p2 = GameObject.Find("Player 2");
         pt = p2.GetComponent<PlaceTrap>();
         cs = p2.GetComponent<CastSpell>();
+
+
+        loader = GetComponent<SceneTransition>();
     }
 
     public void Open(bool speccyWin)
@@ -88,24 +92,24 @@ public class GameOverMenu : MonoBehaviour {
 
     public void onClickRetry()
     {
-        SceneManager.LoadScene("Tower1");
+        StartCoroutine(loader.LoadScene("Tower1"));
     }
     
     public void onClickTutorial()
     {
-        SceneManager.LoadScene("Tutorial");
+        StartCoroutine(loader.LoadScene("Tutorial"));
     }
     
     public void onClickCharacterSelect()
     {
-    	SceneManager.LoadScene("CharacterSelect");
+        StartCoroutine(loader.LoadScene("CharacterSelect"));
     }
 
     public void onClickMenu()
     {
         GameObject musicPlayer = GameObject.Find("MusicPlayer");
         if (musicPlayer != null) Destroy(musicPlayer);
-        SceneManager.LoadScene("Menu");
+        StartCoroutine(loader.LoadScene("Menu"));
     }
     
     public void QuitGame()
@@ -139,7 +143,6 @@ public class GameOverMenu : MonoBehaviour {
             musicPlayer.volume = Mathf.Lerp(0, 1, t / fadeTime);
             yield return null;
         }
-        Debug.Log(musicPlayer.volume);
     }
 }
 

--- a/Assets/Scripts/UI/Menus/MainMenu.cs
+++ b/Assets/Scripts/UI/Menus/MainMenu.cs
@@ -76,7 +76,7 @@ public class MainMenu : MonoBehaviour {
 
     public void OnClickCredits()
     {
-        SceneManager.LoadScene("Credits");
+        StartCoroutine(loader.LoadScene("Credits"));
     }
     
     public void QuitGame()

--- a/Assets/Scripts/UI/Menus/PauseMenu.cs
+++ b/Assets/Scripts/UI/Menus/PauseMenu.cs
@@ -31,8 +31,6 @@ public class PauseMenu : MonoBehaviour {
     private PlayerOneMovement playerMov;
     private PlayerOneLose speccyLose;
     private WinTrigger speccyWin;
-    //For changing controls images
-    private CheckControllers cc;
     private BeginGo countdown;
     private SceneTransition loader;
 
@@ -41,13 +39,18 @@ public class PauseMenu : MonoBehaviour {
     private bool[] onCooldown;
     private bool[] usedTraps;
 
-    private bool controlsUp;
-    private GameObject selectedButton;
 
+    private bool controlsUp;
+
+
+    //Input
+    private int controllerThatPaused = -1; //0 = keyboard, 1 = controller 1, 2 = controller 2; -1 = not paused
+    private StandaloneInputModule inputModule;
+    private float repeatDelay;
+    private GameObject selectedButton;
     CursorLockMode currentLockMode;
     bool cursorVisible;
-
-    private int controllerThatPaused = -1; //0 = keyboard, 1 = controller 1, 2 = controller 2; -1 = not paused
+    private CheckControllers cc;
 
     private void Start()
     {
@@ -66,6 +69,8 @@ public class PauseMenu : MonoBehaviour {
         //input refs
         GameObject inputManager = GameObject.Find("InputManager");
         cc = inputManager.GetComponent<CheckControllers>();
+        inputModule = es.GetComponent<StandaloneInputModule>();
+        repeatDelay = inputModule.repeatDelay;
     }
 
     // Update is called once per frame
@@ -76,8 +81,8 @@ public class PauseMenu : MonoBehaviour {
             {
                 controllerThatPaused = 0;
                 Pause();
-                es.GetComponent<StandaloneInputModule>().submitButton = "Submit_Menu_Click";
-                es.GetComponent<StandaloneInputModule>().verticalAxis = "Nothing";
+                inputModule.submitButton = "Submit_Menu_Click";
+                inputModule.verticalAxis = "Nothing";
 
                 currentLockMode = Cursor.lockState;
                 Cursor.lockState = CursorLockMode.None;
@@ -91,8 +96,8 @@ public class PauseMenu : MonoBehaviour {
                 Cursor.lockState = CursorLockMode.Locked;
 
                 Pause();
-                es.GetComponent<StandaloneInputModule>().submitButton = "Submit_Menu_Joy_1";
-                es.GetComponent<StandaloneInputModule>().verticalAxis = "Vertical_Menu_Stick_Joy_1";
+                inputModule.submitButton = "Submit_Menu_Joy_1";
+                inputModule.verticalAxis = "Vertical_Menu_Stick_Joy_1";
             }
             if (Input.GetButtonDown("Start_Joy_2") && countdown.CountdownFinished && !speccyLose.Lose && !speccyWin.Win)
             {
@@ -102,8 +107,8 @@ public class PauseMenu : MonoBehaviour {
                 Cursor.lockState = CursorLockMode.Locked;
 
                 Pause();
-                es.GetComponent<StandaloneInputModule>().submitButton = "Submit_Menu_Joy_2";
-                es.GetComponent<StandaloneInputModule>().verticalAxis = "Vertical_Menu_Stick_Joy_2";
+                inputModule.submitButton = "Submit_Menu_Joy_2";
+                inputModule.verticalAxis = "Vertical_Menu_Stick_Joy_2";
             }
         }
         else
@@ -182,7 +187,9 @@ public class PauseMenu : MonoBehaviour {
         }
         es.SetSelectedGameObject(selectedButton);
 
-        es.GetComponent<StandaloneInputModule>().submitButton = "Nothing";
+        inputModule.submitButton = "Nothing";
+        inputModule.repeatDelay = repeatDelay;
+
         Time.timeScale = 1f;
 
         Cursor.lockState = currentLockMode;
@@ -197,6 +204,7 @@ public class PauseMenu : MonoBehaviour {
 	public void Pause(){
         //Set buttons not interactable
         selectedButton = es.currentSelectedGameObject;
+        inputModule.repeatDelay = 0.5f;
 
         //Keep track of which spells are on cooldown / uninteractable so we don't set them interactable when we resume.
         //& set the button uninteractable

--- a/Assets/Scripts/UI/Menus/PauseMenu.cs
+++ b/Assets/Scripts/UI/Menus/PauseMenu.cs
@@ -5,9 +5,14 @@ using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
 
+[RequireComponent(typeof(AudioSource))]
 public class PauseMenu : MonoBehaviour {
 	[HideInInspector] public bool GameIsPaused = false;
-	
+
+    [Header("Audio")]
+    [SerializeField] private AudioClip popupSFX;
+    private AudioSource audioSource;
+
 	[SerializeField] GameObject pauseMenuUI;
     [SerializeField] Button[] pauseButtons;
     [SerializeField] GameObject controlsCanvas;
@@ -46,21 +51,21 @@ public class PauseMenu : MonoBehaviour {
 
     private void Start()
     {
+        //player refs
         pt = playerTwo.GetComponent<PlaceTrap>();
         cs = playerTwo.GetComponent<CastSpell>();
         playerMov = playerOne.GetComponent<PlayerOneMovement>();
-        loader = GetComponent<SceneTransition>();
-
-        //Get input refs
-        GameObject inputManager = GameObject.Find("InputManager");
-        //input = inputManager.GetComponent<InputManager>();
-        cc = inputManager.GetComponent<CheckControllers>();
-
-        GameObject gameManager = GameObject.Find("GameManager");
-        countdown = gameManager.GetComponent<BeginGo>();
-
         speccyLose = playerOne.GetComponent<PlayerOneLose>();
         speccyWin = GameObject.Find("WinTrigger").GetComponent<WinTrigger>();
+
+        //game manager refs
+        loader = GetComponent<SceneTransition>();
+        countdown = GetComponent<BeginGo>();
+        audioSource = GetComponent<AudioSource>();
+
+        //input refs
+        GameObject inputManager = GameObject.Find("InputManager");
+        cc = inputManager.GetComponent<CheckControllers>();
     }
 
     // Update is called once per frame
@@ -232,6 +237,7 @@ public class PauseMenu : MonoBehaviour {
         //Bring up Pause menu
         pauseMenuUI.SetActive(true);
         pauseMenuUI.transform.SetAsLastSibling();
+        audioSource.PlayOneShot(popupSFX);
 
         if (controllerThatPaused == 1 || controllerThatPaused == 2)
             es.SetSelectedGameObject(resumeButton.gameObject);
@@ -260,7 +266,7 @@ public class PauseMenu : MonoBehaviour {
     public void Restart()
     {
         Resume();
-        SceneManager.LoadScene("Tower1");
+        StartCoroutine(loader.LoadScene("Tower1"));
     }
     
     public void CharacterSelect()

--- a/Assets/Scripts/UI/Menus/SceneTransition.cs
+++ b/Assets/Scripts/UI/Menus/SceneTransition.cs
@@ -31,6 +31,9 @@ public class SceneTransition : MonoBehaviour
         loadImg.enabled = true;
         fadeAnim.SetBool("end", true);
 
+        fadeAnim.transform.SetAsLastSibling();
+
+        loadImg.transform.SetAsLastSibling();
         //Uncomment this line to see loading screen better; our game loads TOO FAST
         yield return new WaitForSeconds(loadTime);
 

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -271,7 +271,7 @@ InputManager:
     altPositiveButton: 
     gravity: 10
     dead: 0.1
-    sensitivity: 4
+    sensitivity: 10
     snap: 0
     invert: 0
     type: 0
@@ -287,7 +287,7 @@ InputManager:
     altPositiveButton: 
     gravity: 10
     dead: 0.1
-    sensitivity: 4
+    sensitivity: 10
     snap: 0
     invert: 0
     type: 0


### PR DESCRIPTION
- buttons on trap/spell queue should wrap around 
- increased sensitivity & dead value on controller L/R buttons, played around with standalone input module in tower1 scene to try to make it more responsive, still may be a little buggy though and not sure how to fix 😢 
- button sfx on main menu, credits, pause menu, and game over menus - works with both controller and mouse